### PR TITLE
Fix bilingual article breadcrumbs, URLs, and active navigation

### DIFF
--- a/_includes/components/breadcrumbs.html
+++ b/_includes/components/breadcrumbs.html
@@ -4,6 +4,8 @@
   Includes: components/site_nav.html.
   Results in: HTML for the breadcrumbs component.
   Overwrites:
+    breadcrumb_page, breadcrumb_page_path, breadcrumb_page_suffix,
+    breadcrumb_counterpart_path, breadcrumb_counterpart,
     nav_list_link, site_nav, nav_list_simple, nav_list_link_class, nav_category,
     nav_anchor_splits, nav_breadcrumbs, nav_split, nav_split_next, nav_split_test,
     nav_breadcrumb_link, nav_list_end_less, nav_list_end_count, nav_end_index, nav_breadcrumb.
@@ -11,20 +13,41 @@
 
 {%- if page.url != "/" and page.parent and page.title -%}
 
+{%- assign breadcrumb_page = page -%}
+{%- assign breadcrumb_page_path = page.path | default: "" -%}
+{%- assign breadcrumb_page_suffix = breadcrumb_page_path | slice: -6, 6 -%}
+{%- assign breadcrumb_counterpart = nil -%}
+
+{%- comment -%}
+  A paired Persian page is intentionally absent from the visible navigation.
+  Use its English sibling to locate the shared parent chain, while keeping the
+  current Persian page title as the final breadcrumb.
+{%- endcomment -%}
+{%- if breadcrumb_page_suffix == "-fa.md" -%}
+  {%- assign breadcrumb_counterpart_path = breadcrumb_page_path | replace: "-fa.md", "-en.md" -%}
+  {%- assign breadcrumb_counterpart = site.html_pages | where: "path", breadcrumb_counterpart_path | first -%}
+  {%- if breadcrumb_counterpart -%}
+    {%- assign breadcrumb_page = breadcrumb_counterpart -%}
+  {%- endif -%}
+{%- endif -%}
+
 {%- capture site_nav -%}
 {%- include_cached components/site_nav.html all=true -%}
 {%- endcapture -%}
 
+{%- comment -%}
+  Match the stable beginning of the anchor instead of its complete opening tag.
+  Navigation links may contain extra attributes such as `title`.
+{%- endcomment -%}
 {%- capture nav_list_link -%}
-<a href="{{ page.url | relative_url }}" class="nav-list-link">
+<a href="{{ breadcrumb_page.url | relative_url }}" class="nav-list-link"
 {%- endcapture -%}
 
 {%- capture nav_list_simple -%}
 <ul class="nav-list">
 {%- endcapture -%}
 
-{%- capture nav_list_link_class %} class="nav-list-link">
-{%- endcapture -%}
+{%- capture nav_list_link_class -%}class="nav-list-link"{%- endcapture -%}
 
 {%- capture nav_category -%}
 <div class="nav-category">
@@ -64,7 +87,7 @@
 {%- if nav_split_test == nav_split_next -%}
   {%- assign nav_breadcrumb_link =
         nav_split | split: "<a " | last | prepend: "<a " |
-        replace: nav_list_link_class, ">" | append: "</a>" -%}
+        replace: nav_list_link_class, "" | append: "</a>" -%}
   {%- assign nav_breadcrumbs = nav_breadcrumbs | push: nav_breadcrumb_link -%}
 {%- endif -%}
 

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -1,0 +1,18 @@
+// When a language switch is the current URL, Just the Docs activates that
+// small switch link. Mirror the active state onto the article's primary
+// navigation link so the whole row is selected consistently.
+jtd.onReady(function () {
+  var activeLanguageLink = document.querySelector(
+    "#site-nav .nav-list-language-link.active"
+  );
+
+  if (!activeLanguageLink) {
+    return;
+  }
+
+  var primaryLink = activeLanguageLink.previousElementSibling;
+
+  if (primaryLink && primaryLink.classList.contains("nav-list-link")) {
+    primaryLink.classList.add("active");
+  }
+});

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -4,15 +4,15 @@
 jtd.onReady(function () {
   var activeLanguageLink = document.querySelector(
     "#site-nav .nav-list-language-link.active"
-  );
+  )
 
   if (!activeLanguageLink) {
-    return;
+    return
   }
 
-  var primaryLink = activeLanguageLink.previousElementSibling;
+  var primaryLink = activeLanguageLink.previousElementSibling
 
   if (primaryLink && primaryLink.classList.contains("nav-list-link")) {
-    primaryLink.classList.add("active");
+    primaryLink.classList.add("active")
   }
-});
+})

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -92,7 +92,8 @@
     }
 
     &:hover,
-    &:focus {
+    &:focus,
+    &.active {
       color: $link-color;
       text-decoration: none;
       background-color: $feedback-color;

--- a/docs/thinking/essays/acceptance-before-change-en.md
+++ b/docs/thinking/essays/acceptance-before-change-en.md
@@ -35,7 +35,7 @@ permalink: /thinking/essays/acceptance-before-change-en
 
 { Why fighting reality prevents learning | fs-6 }
 
-[نسخه‌ی فارسی](/thinking/essays/acceptance-before-change)
+[نسخه‌ی فارسی](/thinking/essays/acceptance-before-change-fa)
 
 {: .note-title }
 > About this essay

--- a/docs/thinking/essays/acceptance-before-change-fa.md
+++ b/docs/thinking/essays/acceptance-before-change-fa.md
@@ -27,7 +27,7 @@ tags:
   - یادگیری گروهی
   - راهبری
 sitemap: true
-permalink: /thinking/essays/acceptance-before-change
+permalink: /thinking/essays/acceptance-before-change-fa
 ---
 
 # پیش از تغییر، پذیرش؛ درباره‌ی ماهیت انسان و رابطه


### PR DESCRIPTION
## Summary
- restore the complete breadcrumb chain after sidebar links gained extra attributes
- resolve paired Persian pages through their English sibling when building breadcrumbs
- change the Persian essay URL to `/thinking/essays/acceptance-before-change-fa`
- update the English article's Persian-version link to the new URL
- keep the main article row selected when the active URL belongs to the `FA` switch
- visually mark the active `FA` switch

## Root cause
The breadcrumb template searched for an exact navigation anchor ending immediately after `class="nav-list-link"`. The earlier title-tooltip change added a `title` attribute, so the exact anchor could no longer be found. Paired Persian pages are also intentionally omitted as standalone navigation rows, so their breadcrumbs now use the visible English sibling to recover the shared parent chain.

## Expected behavior
- both language pages show their full breadcrumb hierarchy
- the English page remains at `/thinking/essays/acceptance-before-change-en`
- the Persian page is served at `/thinking/essays/acceptance-before-change-fa`
- selecting `FA` keeps the article row highlighted and marks the `FA` switch active

## Testing
CI must pass before merge, including Jekyll builds, HTML validation, and CSS/JavaScript checks.