### PR TITLE
Organize publications by content type, body of work, and theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Validate publication registry
+        run: ruby scripts/validate_publications.rb
       - name: Cache HTMLProofer
         id: cache-htmlproofer
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Validate publication registry
-        run: ruby scripts/validate_publications.rb
+      - name: Run publication validation
+        shell: bash
+        run: |
+          set +e
+          ruby scripts/validate_publications.rb > publication-validation.txt 2>&1
+          status=$?
+          cat publication-validation.txt
+          printf '%s\n' "$status" > publication-validation-status.txt
+          exit 0
+      - name: Upload publication validation diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publication-validation
+          path: |
+            publication-validation.txt
+            publication-validation-status.txt
+          if-no-files-found: error
+          retention-days: 7
+      - name: Enforce publication validation
+        shell: bash
+        run: test "$(cat publication-validation-status.txt)" -eq 0
 
   jekyll-build:
     name: Build (jekyll gem)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           BUNDLE_GEMFILE: fixtures/Gemfile-github-pages
 
   validate:
-    name: Validate HTML
+    name: Validate HTML and navigation
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +106,8 @@ jobs:
           key: ${{ runner.os }}-htmlproofer
       - name: Build Site
         run: bundle exec jekyll build
+      - name: Validate publication navigation
+        run: ruby scripts/validate_publication_navigation.rb _site
       - name: Test with Nu Validator
         uses: Cyb3r-Jak3/html5validator-action@2a593a9f2c10593cbac84791a6fc4c47e9a106c8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  publications:
+    name: Validate publication registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: false
+      - name: Validate publication registry
+        run: ruby scripts/validate_publications.rb
+
   jekyll-build:
     name: Build (jekyll gem)
     strategy:
@@ -77,8 +90,6 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Validate publication registry
-        run: ruby scripts/validate_publications.rb
       - name: Cache HTMLProofer
         id: cache-htmlproofer
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
-          bundler-cache: false
+          show-progress: false
       - name: Validate publication registry
         run: ruby scripts/validate_publications.rb
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,28 +20,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Run publication validation
+      - name: Validate publication registry
         shell: bash
         run: |
-          set +e
-          ruby scripts/validate_publications.rb > publication-validation.txt 2>&1
-          status=$?
-          cat publication-validation.txt
-          printf '%s\n' "$status" > publication-validation-status.txt
-          exit 0
+          set -o pipefail
+          ruby scripts/validate_publications.rb 2>&1 | tee publication-validation.txt
       - name: Upload publication validation diagnostics
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: publication-validation
-          path: |
-            publication-validation.txt
-            publication-validation-status.txt
+          path: publication-validation.txt
           if-no-files-found: error
           retention-days: 7
-      - name: Enforce publication validation
-        shell: bash
-        run: test "$(cat publication-validation-status.txt)" -eq 0
 
   jekyll-build:
     name: Build (jekyll gem)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # okbayat.com — Content Architecture and Editorial Guide
 
-This document defines how content on **okbayat.com** is organized, described, reviewed, and revised. It is the canonical guide for the site's navigation and editorial model and must be updated whenever either changes.
+This document defines how content on **okbayat.com** is organized, described, reviewed, and revised. It is the canonical guide for the site's navigation, editorial model, publication taxonomy, and maintenance rules. Update it whenever any of those systems changes.
 
 ## 1. Purpose of the site
 
@@ -8,8 +8,8 @@ okbayat.com is a durable public record of what Mohammad Bayat is building, study
 
 The work has two connected bodies:
 
-1. **Building systems and organizations** — quantitative systems, software engineering, artificial intelligence, K2Quant, company-building, technical decisions, operating systems, and bounded social-impact initiatives.
-2. **Studying human learning and transformation** — learning, memory, language, identity, context, performance, leadership, group coordination, and quality of life.
+1. **Building systems and organizations** — quantitative systems, software engineering, artificial intelligence, agent systems, K2Quant, company-building, technical decisions, operating systems, and bounded social-impact initiatives.
+2. **Studying human learning and transformation** — learning, memory, language, identity, context, performance, leadership, group coordination, relationships, and quality of life.
 
 The site is not a stream of promotional posts and does not present open questions as settled answers. It should help a reader distinguish among:
 
@@ -19,7 +19,7 @@ The site is not a stream of promotional posts and does not present open question
 - field observations and participant self-reports;
 - software and organizational work that exists in practice;
 - formal experiments, when an appropriate method exists;
-- limitations, uncertainty, and revisions.
+- limitations, uncertainty, failure, and revision.
 
 ## 2. Editorial principles
 
@@ -50,11 +50,11 @@ Program records explain what a program is, where it came from, how it has been r
 
 ### Publish articles with complete metadata and in-page navigation
 
-Every published article-like page must satisfy the metadata, language, SEO, and table-of-contents rules in Section 9. Missing required front matter or a missing in-page table of contents blocks publication.
+Every published article-like page must satisfy the metadata, language, SEO, and table-of-contents rules in this guide. Missing required front matter or a missing in-page table of contents blocks publication.
 
 ### Keep navigation structured
 
-Only durable section hubs belong in the global sidebar. Detailed concepts, old cohorts, course records, and individual notes may use `nav_exclude: true` and remain accessible through their canonical index, internal links, and search.
+Only durable section hubs belong in the global sidebar. Detailed concepts, old cohorts, course records, and individual notes may use `nav_exclude: true` and remain accessible through their canonical index, topical indexes, internal links, and search.
 
 Each section must have only one navigation page. Do not keep two pages with the same `title` and `permalink`.
 
@@ -64,7 +64,100 @@ Do not add `has_children: true` to page front matter. The theme derives child re
 
 Parent pages with child pages already receive an automatically generated child-page table of contents from the theme. Do not add a manual `Explore` or `Table of Contents` section that repeats those links.
 
-## 3. Canonical navigation
+## 3. The two-axis publication architecture
+
+The site organizes writing on two independent axes. They answer different questions and must not be collapsed into one hierarchy.
+
+### Axis 1: content type determines the canonical home
+
+Content type describes authorship, evidence status, and the relationship between the page and its sources:
+
+- Essay
+- Research Note
+- Reading Note
+- Translation
+- Project Record
+- Program Record
+- Experiment Report
+
+A software essay and a relationship essay are both Essays when their main contribution is Mohammad's original argument. A startup book note remains a Reading Note because it depends on a specific source. A translated AI article remains a Translation because its authorship belongs to another writer.
+
+### Axis 2: body of work and theme determine discovery
+
+A canonical page may be linked from one or more topical lenses:
+
+- Building Publications & Notes
+- Human Transformation Publications & Notes
+- Vocora Publications & Notes
+- future project- or series-specific indexes when enough durable work exists
+
+Cross-listing is intentional. It creates several ways to find one work without copying its text or creating competing URLs.
+
+### One conceptual work, one registry entry
+
+`_data/publications.yml` is the machine-readable registry for canonical written works. It currently covers Essays, Research Notes, Reading Notes, and Translations.
+
+Each conceptual work appears exactly once and declares:
+
+```yaml
+- id: stable-work-id
+  content_type: essay
+  primary_body: building
+  bodies_of_work:
+    - building
+  themes:
+    - software-ai-agent-systems
+  project: k2quant
+  summary: A concise description used by publication indexes.
+  editions:
+    - lang: en
+      label: English
+      title: Canonical page title
+      url: /canonical/url
+```
+
+Project Records, Program Records, and Experiment Reports remain indexed manually until their volume justifies extending the registry. They still follow the same one-page and topical-index principles.
+
+### Bilingual and multilingual works
+
+Persian and English editions of the same conceptual work belong under one registry entry. Each edition keeps its own URL, language metadata, title, and page content. Index pages display them as language choices for one work rather than as unrelated publications.
+
+When article files are paired, use a shared `translation_key` and the established `-en.md` / `-fa.md` filename convention.
+
+### Controlled body-of-work identifiers
+
+Use only these body identifiers unless this guide is revised:
+
+- `building`
+- `human-transformation`
+
+A work may belong to both. `primary_body` determines its primary grouping in type indexes; `bodies_of_work` determines all topical indexes where it may appear.
+
+### Controlled theme identifiers
+
+Use focused, durable themes rather than creating a tag for every phrase:
+
+- `software-ai-agent-systems`
+- `entrepreneurship-company-building`
+- `systems-operations-decision-making`
+- `project-reflections-social-impact`
+- `learning-memory-language`
+- `leadership-identity-coordination`
+- `relationships-acceptance`
+- `philosophy-worldview`
+
+A work may use several themes. Add a new controlled theme only when multiple durable works require a distinction that the existing vocabulary cannot express clearly.
+
+### Categories, tags, and taxonomy fields serve different jobs
+
+- `categories` describe canonical site structure and content type, such as `thinking` and `essays`.
+- `tags` describe the specific subject of one page for SEO and search.
+- `bodies_of_work` and `themes` in the central registry control curated discovery across the site.
+- `project`, `program`, and `translation_key` record durable relationships when applicable.
+
+Do not use tags as a substitute for publication architecture.
+
+## 4. Canonical navigation
 
 ```text
 Home
@@ -87,6 +180,7 @@ Human Transformation
 └── Research Log
 
 Building
+├── Publications & Notes
 ├── K2Quant
 ├── Vocora
 │   ├── Research Agenda
@@ -107,6 +201,14 @@ About
 └── Contact
 ```
 
+### Why Thinking is organized by type
+
+Thinking answers: **What kind of written work is this?** Keeping content types distinct protects authorship and evidence boundaries. It also prevents a translated technical article, an unfinished product investigation, and an original essay from being presented as equivalent work.
+
+### Why Building and Human Transformation are topical lenses
+
+Building and Human Transformation answer: **Which body of work or active question does this page inform?** They collect canonical pages from across Thinking, projects, programs, and experiments without republishing them.
+
 ### Why Human Transformation is separate from Leadership
 
 Leadership is one setting in which questions about language, identity, context, performance, and durable change appear. It is not broad enough to contain the full inquiry. Human Transformation is therefore the parent program; Leadership remains a substantial subdomain with its existing resources, programs, coaching material, and field notes.
@@ -120,11 +222,13 @@ K2Quant and Vocora are ongoing bodies of work rather than bounded side projects:
 
 `Projects` is reserved for more bounded products, systems, organizations, and initiatives with a distinct scope and operating history, such as K2 OS and FamilyLink. Projects may be active, paused, completed, discontinued, or inconclusive. `Experiments` is reserved for explicit protocols and results.
 
-## 4. Content types
+## 5. Content types
 
 ### Essays
 
 Original long-form arguments, interpretations, and syntheses written by Mohammad Bayat. An essay should not be used for a direct translation, a source summary, or an unfinished collection of notes.
+
+Essays remain together under `/thinking/essays`. Do not create separate canonical sections such as Technical Essays, Startup Essays, or Human Essays. Use the Building and Human Transformation indexes, controlled themes, and project indexes for subject discovery.
 
 ### Research Notes
 
@@ -157,7 +261,7 @@ Notes, interpretations, disagreements, and questions developed while reading a s
 
 Translations or adaptations of work written by someone else. Every page must name the original author, original title and source, translator or adapter, and whether the page is a complete translation, selected translation, summary, or adaptation. Commentary added by Mohammad must be labelled.
 
-### Project Pages
+### Project Records
 
 Stable descriptions of real work: what existed or exists, why it was built, its operating model, present status, evidence basis, current questions, limitations, and what has not been demonstrated.
 
@@ -191,7 +295,28 @@ Durable descriptions of a facilitated program or recurring practice. A program r
 
 Reports with an explicit question, hypothesis, method, participants or dataset, comparison, predeclared metrics, results, limitations, ethics, and status. `Planned`, `Running`, `Completed`, and `Inconclusive` are all acceptable statuses.
 
-## 5. Human Transformation publishing model
+## 6. Publishing models
+
+### Essays publishing model
+
+- `/thinking/essays/...` is the canonical home for original arguments and synthesis.
+- `/thinking/essays` groups works by primary body and durable theme.
+- bilingual editions appear as one conceptual work with multiple language links.
+- Building and Human Transformation indexes may cross-list the same essay.
+
+### Building publishing model
+
+- `/building` — body-of-work overview;
+- `/building/publications` — curated topical index of writing and records;
+- `/building/k2quant` — K2Quant overview and related writing;
+- `/building/vocora` — Vocora overview and current state;
+- `/building/projects` — bounded project records;
+- `/building/experiments` — protocols and results;
+- `/thinking/...` — canonical written works according to content type.
+
+The Building publications page may group the same work under software, company-building, operations, project reflection, and learning technology when those relationships are real.
+
+### Human Transformation publishing model
 
 Human Transformation is a cross-cutting inquiry rather than a claim that a complete theory of human change already exists.
 
@@ -202,7 +327,7 @@ Each page has one canonical home:
 - `/human-transformation/field-projects` — index of practice-based field projects;
 - `/human-transformation/practice-programs` — index of durable program records;
 - `/human-transformation/source-library` — source lineage and concept-library index;
-- `/human-transformation/publications` — curated index of related output;
+- `/human-transformation/publications` — curated topical index of related output;
 - `/human-transformation/research-log` — dated changes in questions, evidence, methods, and interpretations;
 - `/thinking/research-notes/...` — canonical research, field, literature, and design notes;
 - `/thinking/essays/...` — original arguments and synthesis;
@@ -212,17 +337,16 @@ Each page has one canonical home:
 
 The publications page links to canonical pages; it does not duplicate them.
 
-## 6. Vocora publishing model
+### Vocora publishing model
 
 Vocora content is distributed by type, with one canonical home for each page:
 
 - `/building/vocora` — project overview and current state;
 - `/building/vocora/research-agenda` — questions, methods, and boundaries;
-- `/building/vocora/publications` — curated index of related output;
-- `/building/vocora/research-log` — dated changes in questions, evidence, measurements, and decisions;
+- `/building/vocora/publications` — curated project index;
+- `/building/vocora/research-log` — dated changes in evidence, measurements, and decisions;
 - `/thinking/research-notes/...` — research and design notes;
-- `/thinking/essays/...` — original essays;
-- `/thinking/translations/...` — translated work;
+- `/thinking/translations/...` — translated work, even when an older stable permalink does not mirror the current folder;
 - `/building/experiments/...` — protocols and results when formal experiments exist.
 
 The publications page links to these items; it does not duplicate them.
@@ -276,26 +400,26 @@ Pages involving minors must:
 - report group-level observations where possible;
 - acknowledge selection effects, maturation, family relationships, and observer bias.
 
-## 9. Article metadata, SEO, and table of contents
+## 9. Article metadata, taxonomy, SEO, and table of contents
 
-The rules in this section are mandatory for every published article-like page: Essays, Research Notes, Reading Notes, Translations, Project Pages, Field Notes, Program Records, and Experiment Reports. They do not apply to section indexes, navigation pages, or short utility pages.
+The rules in this section are mandatory for every published article-like page: Essays, Research Notes, Reading Notes, Translations, Project Records, Field Notes, Program Records, and Experiment Reports. They do not apply to section indexes, navigation pages, or short utility pages.
 
-### SEO metadata
-
-The shared site head invokes `jekyll-seo-tag` with `{% seo %}`. Article Markdown must therefore provide complete YAML front matter and must not contain hand-written HTML `<meta>` tags.
+### Required front matter
 
 Every article must include:
 
 - a unique, accurate `title` in the article's primary language;
 - a specific, natural-language `description` that summarizes the page in one sentence and does not merely repeat the title;
 - `author`, plus `translator` for translated or adapted work;
-- `date` for first publication;
+- `date` for first publication when known;
 - `date_modified` for SEO metadata and `last_modified_date` for the theme; update both when the article changes materially;
-- `direction`, `lang`, and `locale` using the language rules below;
-- `seo.type: Article` so article pages are identified as articles in JSON-LD;
+- `direction`, `lang`, and `locale`;
+- `seo.type: Article`;
 - one canonical `permalink` and `sitemap: true`;
 - canonical `categories` for site structure;
 - three to eight focused `tags` that describe the actual subject of the article.
+
+Add content-type fields such as `status`, `project`, `program`, `note_type`, `evidence_level`, `privacy`, `translation_key`, or `image` when they apply. Declare only the immediate `parent`; never repeat higher levels of the hierarchy with `grand_parent`.
 
 Add `image` when a relevant social-sharing image exists. Do not use an irrelevant placeholder image. Do not add `<meta name="keywords">`; front matter `tags` must not be used for keyword stuffing.
 
@@ -306,69 +430,23 @@ Add `image` when a relevant social-sharing image exists. Do not use an irrelevan
 
 `locale` is used by `jekyll-seo-tag` for locale-specific SEO metadata and takes priority over `lang`. Keep both fields present because they serve different consumers.
 
-#### Persian front matter example
+### Publication registry requirement
 
-```yaml
----
-layout: default
-title: عنوان دقیق و یکتای مقاله
-description: "یک توضیح یک‌جمله‌ای دقیق و طبیعی درباره مسئله و محتوای اصلی مقاله."
-parent: Research Notes
-direction: rtl
-lang: fa
-locale: fa_IR
-author: Mohammad Bayat
-date: 2026-07-17
-date_modified: 2026-07-17
-last_modified_date: 2026-07-17
-status: working-note
-seo:
-  type: Article
-categories:
-  - thinking
-  - research-notes
-tags:
-  - یادگیری
-  - زبان
-  - تحول
-sitemap: true
-permalink: /thinking/research-notes/example
----
-```
+Before a canonical Essay, Research Note, Reading Note, or Translation is published, add or update its entry in `_data/publications.yml`.
 
-#### English front matter example
+Validation must confirm:
 
-```yaml
----
-layout: default
-title: A Precise and Unique Article Title
-description: "A specific one-sentence summary of the article's central question and contribution."
-parent: Research Notes
-direction: ltr
-lang: en
-locale: en_US
-author: Mohammad Bayat
-date: 2026-07-17
-date_modified: 2026-07-17
-last_modified_date: 2026-07-17
-status: working-note
-seo:
-  type: Article
-categories:
-  - thinking
-  - research-notes
-tags:
-  - learning
-  - language
-  - transformation
-sitemap: true
-permalink: /thinking/research-notes/example
----
-```
+- every registered `id` is unique;
+- every canonical edition URL is unique;
+- every `content_type`, body identifier, and theme identifier is supported;
+- every registry URL resolves to a published page;
+- every published canonical written work is represented exactly once;
+- language editions of one conceptual work share one registry entry;
+- index pages do not hard-code a second competing classification for the same work.
 
-Add content-type fields such as `status`, `project`, `program`, `note_type`, `evidence_level`, `privacy`, `translator`, or `image` when they apply. Declare only the immediate `parent`; never repeat higher levels of the hierarchy with `grand_parent`.
+### Content labels
 
-Use a content label near the beginning of the page when readers could otherwise misunderstand its status:
+Use a content label near the beginning of a page when readers could otherwise misunderstand its status:
 
 - Essay
 - Open Question
@@ -394,63 +472,14 @@ Use this order at the beginning of every article:
 4. the table of contents;
 5. the first main `##` section.
 
-The table of contents belongs **after the introduction or summary and before the first main section**.
-
-#### Persian article
-
-```markdown
-# عنوان مقاله
-{: .no_toc }
-
-{ زیرعنوان یا برچسب محتوا | fs-6 }
-
-> بلوک وضعیت، نویسنده یا منبع در صورت نیاز
-
-یک یا چند پاراگراف مقدمه یا خلاصه که مسئله، ارزش و محدوده متن را روشن می‌کند.
-
-<details open markdown="block">
-  <summary>
-    فهرست مطالب
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
-
-## بخش اول
-```
-
-#### English article
-
-```markdown
-# Article title
-{: .no_toc }
-
-{ Subtitle or content label | fs-6 }
-
-> Status, author, or source block when needed
-
-One or more opening paragraphs that explain the article's question, value, and scope.
-
-<details open markdown="block">
-  <summary>
-    Table of contents
-  </summary>
-  {: .text-delta }
-1. TOC
-{:toc}
-</details>
-
-## First section
-```
-
-`{:toc}` may appear only once on a page. To omit a heading from the generated table of contents, place `{: .no_toc }` immediately after that heading. Never maintain a manual list of heading links when the generated table of contents can be used.
+The table of contents belongs **after the introduction or summary and before the first main section**. `{:toc}` may appear only once on a page. To omit a heading from the generated table of contents, place `{: .no_toc }` immediately after that heading. Never maintain a manual list of heading links when the generated table of contents can be used.
 
 ## 10. URL, navigation, and language rules
 
 - Every page has one current canonical URL.
-- When a URL changes, update its `permalink`, search the entire repository for the old URL or path, and update every internal reference in the same change.
+- When a URL changes, update its `permalink`, the publication registry, and every internal reference in the same change.
 - Never retain an old URL through a redirect, transition page, legacy page, duplicate page, or compatibility path.
+- Do not change a stable URL merely to make its path mirror a new taxonomy. Canonical type, parent, categories, and indexes can change without unnecessary URL churn.
 - Edit useful content in place and delete obsolete content; do not create archives merely to preserve previous versions.
 - Keep section indexes in the sidebar and detailed pages out of it unless they are intentionally featured.
 - Use one primary language per page and set `direction`, `lang`, and `locale` accordingly.
@@ -464,18 +493,24 @@ Before publishing or merging a structural change:
 1. Confirm that every `parent` matches the immediate parent page's `title` exactly.
 2. Confirm that page front matter contains neither `grand_parent` nor `has_children`.
 3. Confirm that each section has only one navigation page and that no two pages share the same permalink.
-4. When a URL or file path changes, search the entire repository and update every reference to the old value.
-5. Confirm that no redirect, transition page, legacy page, duplicate page, or compatibility path preserves an obsolete URL.
-6. Confirm that useful material was edited in place and obsolete material was deleted rather than archived.
-7. Keep published articles discoverable through their canonical index; use `nav_exclude` only intentionally.
-8. Confirm that every article has the required SEO front matter, language values, dates, and `seo.type`.
-9. Confirm that every article has exactly one generated table of contents after its introduction and before its first main `##` section.
-10. Confirm that project pages state current status, evidence basis, operating dependencies, and what has not been demonstrated.
-11. Confirm that human-related claims identify evidence level, alternative explanations, and limitations.
-12. Confirm that pages involving people satisfy the privacy and consent rules; apply the additional safeguards for children.
-13. Check internal links and the Jekyll build.
-14. Inspect generated pages, SEO tags, and the sidebar.
-15. Update this guide when navigation, definitions, or evidence standards change.
+4. Confirm that every registered work and edition has a unique ID and URL.
+5. Confirm that every canonical Essay, Research Note, Reading Note, and Translation is represented once in `_data/publications.yml`.
+6. Confirm that bilingual editions share one conceptual registry entry.
+7. Confirm that all body and theme identifiers come from the controlled vocabulary.
+8. Confirm that type indexes group by `primary_body` and topical indexes filter by `bodies_of_work` and `themes`.
+9. Confirm that cross-listing links to the canonical page and never copies the article body.
+10. When a URL or file path changes, search the entire repository and update every reference to the old value.
+11. Confirm that no redirect, transition page, legacy page, duplicate page, or compatibility path preserves an obsolete URL.
+12. Confirm that useful material was edited in place and obsolete material was deleted rather than archived.
+13. Keep published articles discoverable through their canonical index and relevant topical indexes; use `nav_exclude` only intentionally.
+14. Confirm that every article has the required SEO front matter, language values, dates when known, and `seo.type`.
+15. Confirm that every article has exactly one generated table of contents after its introduction and before its first main `##` section.
+16. Confirm that project pages state current status, evidence basis, operating dependencies, and what has not been demonstrated.
+17. Confirm that human-related claims identify evidence level, alternative explanations, and limitations.
+18. Confirm that pages involving people satisfy the privacy and consent rules; apply the additional safeguards for children.
+19. Check internal links and the Jekyll build.
+20. Inspect generated pages, registry-rendered indexes, SEO tags, breadcrumbs, language switches, and the sidebar.
+21. Update this guide when navigation, definitions, controlled vocabularies, or evidence standards change.
 
 ## 12. Success criteria
 
@@ -484,6 +519,8 @@ The site is succeeding when a reader can quickly understand:
 - the two main bodies of Mohammad's work;
 - what he is actually building and studying now;
 - which pages are original, translated, exploratory, observed, reported, or tested;
+- where a work canonically belongs and which subjects or projects it informs;
+- how to browse technical, company-building, human, and cross-disciplinary writing without encountering separate competing archives;
 - what evidence supports a claim and what remains uncertain;
 - how K2Quant, Vocora, FamilyLink, Learning Circle, leadership practice, and facilitated programs relate without being collapsed into one kind of work;
 - how questions, methods, and interpretations change over time.

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,33 @@ defaults:
     values:
       layout: "default"
 
+  # Keep canonical article pages discoverable through their type index, topical
+  # indexes, internal links, and search without crowding the global sidebar.
+  # The four section indexes explicitly opt back in with `nav_exclude: false`.
+  - scope:
+      path: "docs/thinking/essays"
+      type: "pages"
+    values:
+      nav_exclude: true
+
+  - scope:
+      path: "docs/thinking/research-notes"
+      type: "pages"
+    values:
+      nav_exclude: true
+
+  - scope:
+      path: "docs/thinking/reading-notes"
+      type: "pages"
+    values:
+      nav_exclude: true
+
+  - scope:
+      path: "docs/thinking/translations"
+      type: "pages"
+    values:
+      nav_exclude: true
+
   # Keep detailed legacy material accessible through its section hub and search
   # without allowing every course, concept, cohort, or source page to crowd the
   # global sidebar. Section index pages explicitly opt back in with
@@ -60,8 +87,6 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
-  - bin/
-  - lib/
   - "*.gemspec"
   - "*.gem"
   - LICENSE.txt

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -201,6 +201,37 @@ works:
         title: مدل جدید راهبری
         url: /thinking/research-notes/a-new-model-of-leadership
 
+  - id: art-groupwork-communication
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - leadership-identity-coordination
+      - relationships-acceptance
+      - learning-memory-language
+    summary: A research note on how art can surface unspoken conflict, fear of judgment, power relations, and recurring interaction patterns inside groups.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: هنر و روابط پنهان یک گروه
+        url: /thinking/research-notes/art-groupwork-communication
+
+  - id: journaling
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - relationships-acceptance
+    summary: A source-based note on expressive writing, narrative construction, difficult experiences, emotion regulation, and claims made for the Pennebaker journaling protocol.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: پروتکل ژورنال‌نویسی
+        url: /thinking/research-notes/journaling
+
   - id: being-and-time
     content_type: reading-note
     primary_body: human-transformation

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,0 +1,331 @@
+# Canonical publication registry for okbayat.com.
+#
+# Each conceptual work appears once. Language editions share one work entry.
+# A page keeps one canonical URL in its content-type section; bodies_of_work and
+# themes provide additional discovery lenses without duplicating the page.
+
+bodies_of_work:
+  building:
+    label: Building Systems & Organizations
+    url: /building
+  human-transformation:
+    label: Human Transformation
+    url: /human-transformation
+
+themes:
+  software-ai-agent-systems:
+    label: Software, AI & Agent Systems
+  entrepreneurship-company-building:
+    label: Entrepreneurship & Company Building
+  systems-operations-decision-making:
+    label: Systems, Operations & Decision-Making
+  project-reflections-social-impact:
+    label: Project Reflections & Social Impact
+  learning-memory-language:
+    label: Learning, Memory & Language
+  leadership-identity-coordination:
+    label: Leadership, Identity & Coordination
+  relationships-acceptance:
+    label: Relationships, Acceptance & Completion
+  philosophy-worldview:
+    label: Philosophy, Worldview & Context
+
+works:
+  - id: phase-oriented-agent-skills
+    content_type: essay
+    primary_body: building
+    bodies_of_work:
+      - building
+    themes:
+      - software-ai-agent-systems
+      - systems-operations-decision-making
+    project: k2quant
+    summary: A reference architecture for explicit phases, lazy loading, bounded side effects, resumable handoffs, and testable agent execution.
+    editions:
+      - lang: en
+        label: English
+        title: Designing Large Agent Skills as Deterministic, Phase-Oriented Systems
+        url: /thinking/essays/phase-oriented-agent-skills
+
+  - id: ten-years-of-familylink
+    content_type: essay
+    primary_body: building
+    bodies_of_work:
+      - building
+    themes:
+      - entrepreneurship-company-building
+      - systems-operations-decision-making
+      - project-reflections-social-impact
+    project: familylink
+    summary: A reflection on a decade-long social-impact project, the limits of its evidence, and the failure of its funding and continuity model.
+    editions:
+      - lang: en
+        label: English
+        title: "Ten Years of FamilyLink: What We Built, Why It Paused, and What Remains"
+        url: /thinking/essays/ten-years-of-familylink
+
+  - id: acceptance-before-change
+    content_type: essay
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - relationships-acceptance
+      - leadership-identity-coordination
+      - learning-memory-language
+    program: human-transformation
+    translation_key: acceptance-before-change
+    summary: An argument about seeing human and relational reality clearly enough to set boundaries, learn, and make responsible change possible.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: پیش از تغییر، پذیرش؛ درباره‌ی ماهیت انسان و رابطه
+        url: /thinking/essays/acceptance-before-change-fa
+      - lang: en
+        label: English
+        title: Acceptance Before Change; On Human Nature and Relationships
+        url: /thinking/essays/acceptance-before-change-en
+
+  - id: vocora-learning-metrics
+    content_type: research-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - systems-operations-decision-making
+    project: vocora
+    summary: Separates practice activity, current performance, and longer-term retention, and defines what Vocora should and should not call learning.
+    editions:
+      - lang: en
+        label: English
+        title: What Should Vocora Measure as Learning?
+        url: /thinking/research-notes/vocora-learning-metrics
+
+  - id: retrieval-practice
+    content_type: research-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - learning-memory-language
+    project: vocora
+    summary: Reviews what retrieval practice can support, what it does not prove, and how the mechanism is currently used in Vocora.
+    editions:
+      - lang: en
+        label: English
+        title: Retrieval Practice in Vocora
+        url: /thinking/research-notes/retrieval-practice
+
+  - id: spaced-practice-and-leitner
+    content_type: research-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - systems-operations-decision-making
+    project: vocora
+    summary: Distinguishes the general spacing effect from the practical but not yet optimized schedule used by Vocora.
+    editions:
+      - lang: en
+        label: English
+        title: Spaced Practice and the Leitner System
+        url: /thinking/research-notes/spaced-practice-and-leitner
+
+  - id: ethical-gamification
+    content_type: research-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - software-ai-agent-systems
+      - systems-operations-decision-making
+    project: vocora
+    summary: Defines autonomy, motivation, privacy, and evidence guardrails for goals, streaks, progress feedback, and sharing.
+    editions:
+      - lang: en
+        label: English
+        title: Ethical Gamification in Vocora
+        url: /thinking/research-notes/ethical-gamification
+
+  - id: hebbs-rule
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+      - building
+    themes:
+      - learning-memory-language
+      - relationships-acceptance
+    project: vocora
+    summary: A cautious conceptual note on Hebbian learning, association, and the limits of using one neural principle to explain emotion or behavior.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: قانون هب و شکل‌گیری تداعی‌ها
+        url: /thinking/research-notes/hebbs-rule
+
+  - id: crucibles-of-leadership
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - leadership-identity-coordination
+      - learning-memory-language
+    summary: Notes on Warren Bennis and Robert Thomas's account of difficult experience, identity, learning, and leadership development.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: بوته‌های آزمایش راهبری
+        url: /thinking/research-notes/crucibles-of-leadership
+
+  - id: a-new-model-of-leadership
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - leadership-identity-coordination
+      - philosophy-worldview
+    summary: A source-based note on the ontological and phenomenological model of leadership and the difference between knowing about leadership and leading in action.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: مدل جدید راهبری
+        url: /thinking/research-notes/a-new-model-of-leadership
+
+  - id: being-and-time
+    content_type: reading-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - philosophy-worldview
+      - leadership-identity-coordination
+      - learning-memory-language
+    summary: A reading of Being and Time in dialogue with Speaking Being and the author's experience of leadership, language, and human action.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: از هستی تا راهبری
+        url: /thinking/reading-notes/being-and-time
+
+  - id: holistic-learning
+    content_type: reading-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - leadership-identity-coordination
+      - philosophy-worldview
+    summary: A critical interdisciplinary review of holistic learning, ways of being, Heidegger, and the possibility of evidence-aware leadership education.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: یادگیری کلنگر
+        url: /thinking/reading-notes/holistic-learning
+
+  - id: smarter-faster-better
+    content_type: reading-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - systems-operations-decision-making
+      - leadership-identity-coordination
+    summary: Notes on decision-making, focus, motivation, teams, and the design of sustainable productivity.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: باهوش‌تر، سریع‌تر، بهتر
+        url: /thinking/reading-notes/smarter-faster-better
+
+  - id: tao-te-ching
+    content_type: reading-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - philosophy-worldview
+      - leadership-identity-coordination
+    summary: Notes on the Tao Te Ching, simplicity, effortless action, Eastern philosophy, life, and leadership.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: تائو تِ چینگ
+        url: /thinking/reading-notes/tao-te-ching
+
+  - id: the-infinite-game
+    content_type: reading-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - entrepreneurship-company-building
+      - leadership-identity-coordination
+      - systems-operations-decision-making
+    summary: A reading of long-term leadership, purpose, trust, resilience, and organizations built for more than short-term wins.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: بازی بی‌نهایت
+        url: /thinking/reading-notes/the-infinite-game
+
+  - id: the-power-of-habit
+    content_type: reading-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+      - building
+    themes:
+      - learning-memory-language
+      - leadership-identity-coordination
+      - systems-operations-decision-making
+    summary: Notes on habit loops, keystone habits, and behavior change in individuals, organizations, and societies.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: قدرت عادت
+        url: /thinking/reading-notes/the-power-of-habit
+
+  - id: thinking-fast-and-slow
+    content_type: reading-note
+    primary_body: building
+    bodies_of_work:
+      - building
+      - human-transformation
+    themes:
+      - systems-operations-decision-making
+      - learning-memory-language
+    summary: Notes on fast and slow thinking, cognitive bias, intuition, judgment, and decision-making in life and work.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: تفکر سریع و کند
+        url: /thinking/reading-notes/thinking-fast-and-slow
+
+  - id: how-your-brain-finds-patterns
+    content_type: translation
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+      - building
+    themes:
+      - learning-memory-language
+    project: vocora
+    summary: A Persian translation and adaptation of a general introduction to statistical learning and language-pattern detection.
+    editions:
+      - lang: fa
+        label: فارسی
+        title: مغز چگونه الگوهای زبان را دنبال می‌کند
+        url: /thinking/essays/how-your-brain-finds-patterns

--- a/_includes/components/nav/children.html
+++ b/_includes/components/nav/children.html
@@ -1,10 +1,12 @@
 {%- comment -%}
   Include as: {%- include components/nav/children.html node=node ancestors=title_array all=bool -%}
-  Depends on: include.node, include.ancestors, include.all, nav_parenthood, nav_top_node_titles.
+  Depends on: include.node, include.ancestors, include.all, nav_parenthood,
+  nav_top_node_titles, site.data.publications.
   Includes: components/nav/sorted.html.
   Assigns to: nav_children.
   Overwrites:
-    nav_candidates, nav_child, nav_child_ok.
+    nav_candidates, nav_child, nav_child_ok, nav_child_is_publication,
+    nav_publication_work, nav_publication_edition.
 {%- endcomment -%}
 
 {%- assign nav_children = "" | split: "" -%}
@@ -16,6 +18,25 @@
 
   {%- for nav_child in nav_candidates -%}
     {%- assign nav_child_ok = true -%}
+    {%- assign nav_child_is_publication = false -%}
+
+    {%- if include.all != true -%}
+      {%- for nav_publication_work in site.data.publications.works -%}
+        {%- for nav_publication_edition in nav_publication_work.editions -%}
+          {%- if nav_publication_edition.url == nav_child.url -%}
+            {%- assign nav_child_is_publication = true -%}
+            {%- break -%}
+          {%- endif -%}
+        {%- endfor -%}
+        {%- if nav_child_is_publication -%}
+          {%- break -%}
+        {%- endif -%}
+      {%- endfor -%}
+
+      {%- if nav_child.nav_exclude == true or nav_child_is_publication -%}
+        {%- assign nav_child_ok = false -%}
+      {%- endif -%}
+    {%- endif -%}
 
     {%- if nav_child.grand_parent and nav_child.grand_parent != include.node.parent -%}
       {%- assign nav_child_ok = false -%}
@@ -32,7 +53,7 @@
       and nav_child can also be 2nd-level. This is for backwards compatibility with
       existing 3-level sites.
     {%- endcomment -%}
-    {%- if nav_child.grand_parent == nil and nav_child.ancestor == nil and 
+    {%- if nav_child.grand_parent == nil and nav_child.ancestor == nil and
           nav_top_node_titles contains nav_child.parent and include.ancestors.size >= 1 -%}
       {%- assign nav_child_ok = false -%}
     {%- endif -%}

--- a/docs/building/experiments/experiments.md
+++ b/docs/building/experiments/experiments.md
@@ -2,7 +2,7 @@
 layout: default
 title: Experiments
 parent: Building
-nav_order: 4
+nav_order: 5
 direction: ltr
 description: "Documented product and research experiments, including methods, results, and limitations."
 permalink: /building/experiments

--- a/docs/building/index.md
+++ b/docs/building/index.md
@@ -13,6 +13,12 @@ This section documents work that exists in practice: companies, software, system
 
 It is organized by what is being built rather than by every question that the work raises. Cross-cutting questions about learning, language, identity, context, performance, leadership, and coordination are indexed separately under [Human Transformation](/human-transformation).
 
+## Publications & Notes
+
+[Building Publications & Notes](/building/publications) is the topical index for essays, research notes, reading notes, translations, project reflections, and experiment reports about software, AI, agent systems, entrepreneurship, company-building, operations, and decision-making.
+
+The writing remains in its canonical content-type section. This index creates a coherent Building lens without creating separate copies or parallel technical and startup blogs.
+
 ## Main Bodies of Work
 
 ### [K2Quant](/building/k2quant)

--- a/docs/building/k2quant/index.md
+++ b/docs/building/k2quant/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: K2Quant
 parent: Building
-nav_order: 1
+nav_order: 2
 direction: ltr
 description: "Mohammad Bayat's company-building work in quantitative systems, software, artificial intelligence, and technical operations."
 permalink: /building/k2quant
@@ -21,6 +21,16 @@ K2Quant is the main company-building part of my work. It is where I develop and 
 - Developing artificial-intelligence tools, skills, and agent-based workflows
 - Developing tools that support research, analysis, and operations
 - Learning from the day-to-day work of building a technical organization
+
+## Related Writing
+
+{% for work in site.data.publications.works %}
+{% if work.project == "k2quant" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+The wider technical, organizational, and company-building archive is collected in [Building Publications & Notes](/building/publications).
 
 ## Relationship to Human Transformation
 

--- a/docs/building/projects/index.md
+++ b/docs/building/projects/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Projects
 parent: Building
-nav_order: 3
+nav_order: 4
 direction: ltr
 description: "Bounded products, systems, organizations, and social-impact initiatives built, operated, or explored by Mohammad Bayat."
 permalink: /building/projects

--- a/docs/building/publications.md
+++ b/docs/building/publications.md
@@ -1,0 +1,70 @@
+---
+layout: default
+title: Publications & Notes
+parent: Building
+nav_order: 1
+direction: ltr
+description: "A curated index of essays, research notes, reading notes, translations, and project records about software, AI, entrepreneurship, organizations, and systems."
+permalink: /building/publications
+---
+
+# Building Publications & Notes
+
+This page is a topical index for work about building systems and organizations. Each item remains in its canonical content-type section—Essay, Research Note, Reading Note, Translation, Project Record, or Experiment Report—so authorship, evidence status, and revision history remain clear.
+
+Some works appear under more than one theme because software, company-building, decision-making, and organizational design overlap. Cross-listing is intentional; the underlying page is not duplicated.
+
+## Bodies of Work and Project Records
+
+- [K2Quant](/building/k2quant) — quantitative systems, software, artificial intelligence, technical operations, and company-building.
+- [Vocora](/building/vocora) — an open-source research-and-building project about learning, memory, language practice, and learning technology.
+- [Projects](/building/projects) — bounded products, systems, organizations, and social-impact initiatives with explicit operating status.
+- [Experiments](/building/experiments) — protocols and results when an explicit method, measurement plan, and interpretation exist.
+
+## Software, AI & Agent Systems
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "building" and work.themes contains "software-ai-agent-systems" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+## Entrepreneurship & Company Building
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "building" and work.themes contains "entrepreneurship-company-building" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+## Systems, Operations & Decision-Making
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "building" and work.themes contains "systems-operations-decision-making" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+## Project Reflections & Social Impact
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "building" and work.themes contains "project-reflections-social-impact" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+- **Project record:** [FamilyLink](/family-link) — the factual record of the project's purpose, operating history, current paused status, evidence limits, and conditions for a responsible return.
+
+## Learning Technology
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "building" and work.themes contains "learning-memory-language" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+Project-specific context, design status, and external documentation remain collected in [Vocora Publications & Notes](/building/vocora/publications).
+
+## Publication Rule
+
+A work is included here because it informs an active Building question, not because it promotes a company or confirms a preferred conclusion. Failed projects, negative findings, inconclusive tests, revised interpretations, and explicit limitations are eligible when they are documented clearly.

--- a/docs/building/vocora/index.md
+++ b/docs/building/vocora/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Vocora
 parent: Building
-nav_order: 2
+nav_order: 3
 direction: ltr
 description: "An open-source research-and-building project about learning, memory, language practice, and learning technology."
 permalink: /building/vocora

--- a/docs/building/vocora/publications.md
+++ b/docs/building/vocora/publications.md
@@ -4,61 +4,35 @@ title: Publications & Notes
 parent: Vocora
 nav_order: 2
 direction: ltr
-description: "A curated index of research notes, translations, and design documentation connected to Vocora."
+description: "A curated index of research notes, translations, reading, and project documentation connected to Vocora."
 permalink: /building/vocora/publications
 ---
 
 # Vocora Publications & Notes
 
-This page collects work related to Vocora. Each item remains in its canonical section according to its type. Inclusion here means that the item informs the project; it does not mean that it is a peer-reviewed publication.
+This page collects work related to Vocora. Each item remains in its canonical section according to its content type. Inclusion here means that the item informs the project; it does not mean that it is a peer-reviewed publication or that a product-specific effect has been established.
 
 ## Research and Design Notes
 
-### [What Should Vocora Measure as Learning?](/thinking/research-notes/vocora-learning-metrics)
+{% for work in site.data.publications.works %}
+{% if work.project == "vocora" and work.content_type == "research-note" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
-**Type:** Working research and design note  
-**Status:** Published; requires future empirical evaluation
+## Translations and Source Material
 
-Distinguishes practice activity, same-session performance, and longer-term retention, and explains the current product metrics and guardrails.
-
-### [Retrieval Practice in Vocora](/thinking/research-notes/retrieval-practice)
-
-**Type:** Working research note  
-**Status:** Published; application-specific effects not yet evaluated
-
-Reviews why active recall is used, which claims the evidence can support, and what a delayed recall measure still needs to establish.
-
-### [Spaced Practice and the Leitner System](/thinking/research-notes/spaced-practice-and-leitner)
-
-**Type:** Working research and design note  
-**Status:** Published; current schedule not empirically optimized
-
-Separates the general spacing effect from the practical but unvalidated intervals used by Vocora's current Leitner-style scheduler.
-
-### [Ethical Gamification in Vocora](/thinking/research-notes/ethical-gamification)
-
-**Type:** Working research and design note  
-**Status:** Published; current feature effects not causally evaluated
-
-Defines autonomy, competence, privacy, and guardrail requirements for goals, streaks, progress feedback, and sharing.
-
-### [قانون هب و شکل‌گیری تداعی‌ها](/thinking/research-notes/hebbs-rule)
-
-**Type:** Working conceptual note  
-**Language:** Persian
-
-A cautious introduction to Hebbian learning and its limits when used to think about learned emotional associations. It is not a clinical or therapeutic guide.
-
-## Translations and Reading Notes
-
-### [مغز چگونه الگوهای زبان را دنبال می‌کند](/thinking/essays/how-your-brain-finds-patterns)
-
-**Type:** Translation and adaptation  
-**Original author:** Cindy Blanco, Ph.D.
-
-A general introduction to statistical learning in language, published with clear attribution to the original source.
+{% for work in site.data.publications.works %}
+{% if work.project == "vocora" and work.content_type == "translation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
 ## Project Documentation
+
+### [Research Agenda](/building/vocora/research-agenda)
+
+The current questions, methods, boundaries, and claims that would require stronger evaluation.
 
 ### [Research Log](/building/vocora/research-log)
 

--- a/docs/human-transformation/publications.md
+++ b/docs/human-transformation/publications.md
@@ -4,44 +4,61 @@ title: Publications & Notes
 parent: Human Transformation
 nav_order: 6
 direction: ltr
-description: "A curated index of canonical essays, research notes, field records, translations, and project pages related to human transformation."
+description: "A curated index of canonical essays, research notes, reading notes, translations, field records, and project pages related to human transformation."
 permalink: /human-transformation/publications
 ---
 
 # Human Transformation Publications & Notes
 
-This page is a curated index. Each item remains in its canonical content section so authorship, evidence status, and revision history are not duplicated or blurred.
+This page is a topical index. Each item remains in its canonical content section so authorship, evidence status, language metadata, and revision history are not duplicated or blurred.
+
+A work may appear under more than one theme because learning, identity, relationships, leadership, language, and worldview overlap. Cross-listing does not create a second copy of the page.
 
 ## Program and Field Records
 
-- [Human Transformation Research Agenda](/human-transformation/research-agenda) — active questions and boundaries.
+- [Human Transformation Research Agenda](/human-transformation/research-agenda) — active questions, evidence boundaries, and methods.
 - [Learning Circle](/human-transformation/field-projects/learning-circle) — children's autonomy, peer teaching, group coordination, and facilitator withdrawal.
 - [Mastery for Life Program Record](/human-transformation/practice-programs/mastery-for-life) — program history, questions, participant self-reports, limitations, and evaluation needs.
+- [Leadership](/leadership) — hub for the existing practice, coaching, course, research, and source archive.
 
-## Leadership and Identity
+## Relationships, Acceptance & Completion
 
-- [Leadership](/leadership) — hub for the existing practice and source archive.
-- [Leadership Field Inquiry](/leadership/research) — current status and evidence boundaries.
-- [بوته‌های آزمایش راهبری](/thinking/research-notes/crucibles-of-leadership) — source-based notes on difficult experience, identity, and leadership.
-- [مدل جدید راهبری](/thinking/research-notes/a-new-model-of-leadership) — source-based material on ontological and phenomenological leadership.
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "human-transformation" and work.themes contains "relationships-acceptance" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
-## Relationships, Acceptance, and Completion
+## Leadership, Identity & Coordination
 
-- [پیش از تغییر، پذیرش؛ درباره‌ی ماهیت انسان و رابطه](/thinking/essays/acceptance-before-change) — Persian essay on resistance, acceptance, boundaries, learning, and transformation in relationships, groups, and organizations.
-- [Acceptance Before Change; On Human Nature and Relationships](/thinking/essays/acceptance-before-change-en) — English version of the essay.
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "human-transformation" and work.themes contains "leadership-identity-coordination" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
-## Learning and Memory
+## Learning, Memory & Language
 
-- [Vocora](/building/vocora) — a bounded research-and-building project about learning and learning technology.
-- [Vocora Research Agenda](/building/vocora/research-agenda) — retrieval, spacing, feedback, motivation, language practice, and measurement.
-- [Research Notes](/thinking/research-notes) — canonical home for current evidence reviews and design notes.
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "human-transformation" and work.themes contains "learning-memory-language" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
-## Language, Worldview, and Context
+Vocora is a bounded software project within this wider inquiry. Its project-specific writing is collected in [Vocora Publications & Notes](/building/vocora/publications).
+
+## Philosophy, Worldview & Context
+
+{% for work in site.data.publications.works %}
+{% if work.bodies_of_work contains "human-transformation" and work.themes contains "philosophy-worldview" %}
+- **{{ work.content_type | replace: "-", " " | capitalize }}:** {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
 - [Podcast: Inja-Anja](/voice/podcast) — conversations about worldview, frames of reference, perception, language, and integrity.
-- [Leadership Source Library](/leadership/resources) — translations and concept material whose source lineage should remain visible.
-- [Translations](/thinking/translations) — canonical attributed translations and adaptations.
+- [Human Transformation Source Library](/human-transformation/source-library) — source lineage and concept maps.
+- [Leadership Source Library](/leadership/resources) — translations and concept material whose source lineage remains visible.
 
 ## Publication Rule
 
-A page is added here because it contributes to an active question, not because it confirms a preferred answer. Inconclusive notes, revised interpretations, and negative observations are eligible when they are documented clearly.
+A page is added here because it contributes to an active question, not because it confirms a preferred answer. Inconclusive notes, revised interpretations, negative observations, and contradictory evidence are eligible when they are documented clearly.

--- a/docs/thinking/essays/index.md
+++ b/docs/thinking/essays/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Essays
 parent: Thinking
 nav_order: 1
+nav_exclude: false
 direction: ltr
 description: "Original long-form arguments and syntheses, organized by body of work and theme without duplicating their canonical pages."
 permalink: /thinking/essays

--- a/docs/thinking/essays/index.md
+++ b/docs/thinking/essays/index.md
@@ -4,25 +4,74 @@ title: Essays
 parent: Thinking
 nav_order: 1
 direction: ltr
-description: "Original long-form arguments, interpretations, and conceptual syntheses by Mohammad Bayat."
+description: "Original long-form arguments and syntheses, organized by body of work and theme without duplicating their canonical pages."
 permalink: /thinking/essays
 ---
 
 # Essays
 
-Essays are original long-form writing by Mohammad Bayat. They develop an argument, interpretation, or synthesis rather than only summarizing a source.
+Essays are original long-form arguments, interpretations, and syntheses by Mohammad Bayat. Their canonical home is determined by **content type**, not by subject: a software-architecture essay, a company-building reflection, and an essay about human relationships can all belong here.
 
-A page belongs here when its main contribution is the author's own reasoning. Other content has a separate home:
+Subject discovery is handled separately. Each conceptual work is classified by one or more **bodies of work** and **themes**, then linked from the relevant Building or Human Transformation publication index. A work still has one canonical page and one revision history.
+
+A page belongs elsewhere when its main purpose is different:
 
 - unfinished investigations and evidence reviews belong in [Research Notes](/thinking/research-notes);
-- reading-specific reflections belong in [Reading Notes](/thinking/reading-notes);
+- source-specific reflections belong in [Reading Notes](/thinking/reading-notes);
 - work written by another author belongs in [Translations](/thinking/translations) with clear attribution.
 
-An essay may draw on books, papers, field observations, and practice, but it should identify those sources and distinguish evidence, observation, participant self-report, and interpretation.
+## Browse by Body of Work
 
-## Published Essays
+### Building Systems & Organizations
 
-- [Designing Large Agent Skills as Deterministic, Phase-Oriented Systems](/thinking/essays/phase-oriented-agent-skills) — a reference architecture for explicit phases, lazy loading, bounded side effects, resumable handoffs, and testable execution.
-- [Ten Years of FamilyLink: What We Built, Why It Paused, and What Remains](/thinking/essays/ten-years-of-familylink) — a reflection on a long-running social-impact project, the limits of its evidence, and the failure of its funding model.
-- [پیش از تغییر، پذیرش؛ درباره‌ی ماهیت انسان و رابطه](/thinking/essays/acceptance-before-change) — Persian essay on acceptance, boundaries, learning, and transformation in relationships, groups, and organizations.
-- [Acceptance Before Change; On Human Nature and Relationships](/thinking/essays/acceptance-before-change-en) — English version of the essay.
+{% for work in site.data.publications.works %}
+{% if work.content_type == "essay" and work.bodies_of_work contains "building" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+Related technical, organizational, startup, and project writing is also collected in [Building Publications & Notes](/building/publications).
+
+### Human Transformation
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "essay" and work.bodies_of_work contains "human-transformation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+Related writing about learning, identity, language, relationships, leadership, and coordination is also collected in [Human Transformation Publications & Notes](/human-transformation/publications).
+
+## Browse by Theme
+
+### Software, AI & Agent Systems
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "essay" and work.themes contains "software-ai-agent-systems" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+### Entrepreneurship, Company Building & Project Reflection
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "essay" and work.themes contains "entrepreneurship-company-building" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+### Relationships, Identity & Human Transformation
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "essay" and work.bodies_of_work contains "human-transformation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %}<br>{% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+## Language Editions
+
+Persian and English versions of the same conceptual work are displayed as one entry with multiple language links. Each edition keeps its own URL and language metadata, while `translation_key` or the central publication registry prevents the archive from presenting one idea as two unrelated works.
+
+## Publication Rule
+
+The publication registry in `_data/publications.yml` is the machine-readable source for content type, body of work, theme, project relationship, language editions, and canonical URLs. Index pages may cross-list a work under several relevant lenses, but they must not copy or republish its body.

--- a/docs/thinking/index.md
+++ b/docs/thinking/index.md
@@ -11,11 +11,20 @@ permalink: /thinking
 
 This section contains written work at different stages and with different purposes. The label matters: an essay, open question, field note, source note, and translation should not be presented as the same kind of authorship or evidence.
 
+## How the Writing Is Organized
+
+The site uses two complementary axes:
+
+1. **Content type determines the canonical home.** Essays, Research Notes, Reading Notes, and Translations each describe a different relationship to authorship, evidence, and completeness.
+2. **Body of work and theme determine discovery.** The same canonical page may also be linked from [Building Publications & Notes](/building/publications), [Human Transformation Publications & Notes](/human-transformation/publications), or a project-specific index such as [Vocora Publications & Notes](/building/vocora/publications).
+
+A page is never copied merely because it belongs to more than one subject. Cross-listing creates multiple ways to find the work while preserving one URL, one text, and one revision history.
+
 ## Sections
 
 ### [Essays](/thinking/essays)
 
-Original long-form arguments, interpretation, and synthesis written by Mohammad Bayat.
+Original long-form arguments, interpretations, and syntheses written by Mohammad Bayat. Essays are grouped by body of work and theme without being split into separate technical, startup, or human essay archives.
 
 ### [Research Notes](/thinking/research-notes)
 
@@ -42,5 +51,3 @@ Research-related pages should distinguish among:
 - questions that remain open.
 
 The purpose is not to make every page sound final. It is to make the status of each idea visible.
-
-Questions and writing connected to learning, language, identity, context, performance, leadership, and quality of life are also indexed in [Human Transformation Publications & Notes](/human-transformation/publications).

--- a/docs/thinking/reading-notes/index.md
+++ b/docs/thinking/reading-notes/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Reading Notes
 parent: Thinking
 nav_order: 3
+nav_exclude: false
 direction: ltr
 description: "Source-specific notes and interpretations, grouped by their primary relevance to building systems or human transformation."
 permalink: /thinking/reading-notes

--- a/docs/thinking/reading-notes/index.md
+++ b/docs/thinking/reading-notes/index.md
@@ -4,13 +4,31 @@ title: Reading Notes
 parent: Thinking
 nav_order: 3
 direction: ltr
-description: "Notes, questions, disagreements, and interpretations developed from identifiable books, papers, talks, and other sources."
+description: "Source-specific notes and interpretations, grouped by their primary relevance to building systems or human transformation."
 permalink: /thinking/reading-notes
 ---
 
 # Reading Notes
 
 Reading Notes document what I am learning from a specific source: its main ideas, questions it raises, points of disagreement, connections to my work, and claims that need further evidence.
+
+Their canonical home is based on source dependence. A note may inform both Building and Human Transformation and may therefore appear in both topical publication hubs, while remaining one page here.
+
+## Organizations, Decisions & Long-Term Building
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "reading-note" and work.primary_body == "building" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+## Human Learning, Philosophy & Leadership
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "reading-note" and work.primary_body == "human-transformation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
 
 ## Source Types
 

--- a/docs/thinking/research-notes/index.md
+++ b/docs/thinking/research-notes/index.md
@@ -4,7 +4,7 @@ title: Research Notes
 parent: Thinking
 nav_order: 2
 direction: ltr
-description: "Working investigations, open questions, field observations, literature reviews, design decisions, and revisions."
+description: "Working investigations, evidence reviews, field observations, and design decisions grouped by their primary body of work."
 permalink: /thinking/research-notes
 ---
 
@@ -13,6 +13,28 @@ permalink: /thinking/research-notes
 Research Notes contain work in progress: a question being clarified, evidence being reviewed, a field observation being documented, a design assumption being examined, or an interpretation being revised.
 
 They are not automatically scientific papers and are not assumed to be peer reviewed. A strong note should make its status, evidence level, alternative explanations, and uncertainty visible.
+
+Each note remains canonical here because **Research Note** describes its epistemic and editorial status. Project and subject indexes provide additional discovery without moving or duplicating the page.
+
+## Building, Product Design & Learning Technology
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "research-note" and work.primary_body == "building" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+These notes are also collected in [Building Publications & Notes](/building/publications) and, when connected to the project, [Vocora Publications & Notes](/building/vocora/publications).
+
+## Human Learning, Leadership & Transformation
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "research-note" and work.primary_body == "human-transformation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+These notes are also collected in [Human Transformation Publications & Notes](/human-transformation/publications).
 
 ## Common Note Types
 
@@ -45,10 +67,3 @@ A record of a project or program decision, the assumptions behind it, alternativ
 9. Limitations, privacy, and uncertainty
 10. Open questions and next step
 11. References
-
-## Related Programs
-
-- Notes connected to Vocora are also collected in [Vocora Publications & Notes](/building/vocora/publications).
-- Notes connected to learning, language, identity, context, performance, leadership, and quality of life are indexed in [Human Transformation Publications & Notes](/human-transformation/publications).
-
-Each note remains here as its canonical page.

--- a/docs/thinking/research-notes/index.md
+++ b/docs/thinking/research-notes/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Research Notes
 parent: Thinking
 nav_order: 2
+nav_exclude: false
 direction: ltr
 description: "Working investigations, evidence reviews, field observations, and design decisions grouped by their primary body of work."
 permalink: /thinking/research-notes

--- a/docs/thinking/translations/index.md
+++ b/docs/thinking/translations/index.md
@@ -4,13 +4,25 @@ title: Translations
 parent: Thinking
 nav_order: 4
 direction: ltr
-description: "Attributed translations and adaptations of selected writing."
+description: "Attributed translations and adaptations, organized by the questions and projects they inform."
 permalink: /thinking/translations
 ---
 
 # Translations
 
-This section contains translations and adaptations of work written by other authors.
+This section contains translations and adaptations of work written by other authors. The canonical home is determined by authorship: a translated technical, startup, or human-learning text remains a Translation rather than becoming an Essay because of its subject.
+
+## Published Translations & Adaptations
+
+{% for work in site.data.publications.works %}
+{% if work.content_type == "translation" %}
+- {% for edition in work.editions %}[{{ edition.title }}]({{ edition.url }}){% if work.editions.size > 1 %} — {{ edition.label }}{% endif %}{% unless forloop.last %} · {% endunless %}{% endfor %} — {{ work.summary }}
+{% endif %}
+{% endfor %}
+
+Translations related to learning technology are also collected in [Vocora Publications & Notes](/building/vocora/publications). Older leadership translations and source material remain accessible through the [Human Transformation Source Library](/human-transformation/source-library) and [Leadership Source Library](/leadership/resources).
+
+## Required Attribution
 
 Every page should identify:
 

--- a/docs/thinking/translations/index.md
+++ b/docs/thinking/translations/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Translations
 parent: Thinking
 nav_order: 4
+nav_exclude: false
 direction: ltr
 description: "Attributed translations and adaptations, organized by the questions and projects they inform."
 permalink: /thinking/translations

--- a/index.md
+++ b/index.md
@@ -19,9 +19,13 @@ OkBayat.com is a public record of the questions, field projects, evidence, softw
 
 [K2Quant](/building/k2quant) is the main company-building part of my work. It brings together quantitative systems, software engineering, artificial intelligence, decision-support tools, and the practical work of operating a technical organization.
 
+Writing about software, AI, agent systems, entrepreneurship, company-building, operations, and project lessons is collected in [Building Publications & Notes](/building/publications).
+
 ### Studying Human Transformation
 
 [Human Transformation](/human-transformation) is an independent inquiry into learning, language, identity, context, performance, leadership, group coordination, and quality of life. It connects reading with field projects and practice-based observation without treating those observations as formal scientific proof.
+
+Related essays, research notes, reading notes, translations, and field records are collected in [Human Transformation Publications & Notes](/human-transformation/publications).
 
 ## Questions I Am Working On
 
@@ -60,11 +64,14 @@ The evolving set of questions is recorded in the [Human Transformation Research 
 - **Building** documents companies, software, projects, and formal experiments when they exist.
 - **Program Records** distinguish program history and participant self-report from evidence of efficacy.
 
+Content type determines the canonical home of a page. Body-of-work and theme indexes create additional ways to discover it without copying the article or fragmenting the site into separate technical, startup, and human blogs.
+
 ## Start Here
 
+- [Essays](/thinking/essays)
+- [Building Publications & Notes](/building/publications)
+- [Human Transformation Publications & Notes](/human-transformation/publications)
 - [Human Transformation Research Agenda](/human-transformation/research-agenda)
-- [Learning Circle Field Project](/human-transformation/field-projects/learning-circle)
 - [Vocora](/building/vocora)
 - [K2Quant](/building/k2quant)
-- [Research Notes](/thinking/research-notes)
 - [Current Work](/about/current-interests)

--- a/scripts/validate_publication_navigation.rb
+++ b/scripts/validate_publication_navigation.rb
@@ -1,0 +1,70 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "pathname"
+require "yaml"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+REGISTRY_PATH = ROOT.join("_data/publications.yml")
+INDEX_PATH = SITE_DIR.join("index.html")
+
+unless INDEX_PATH.file?
+  warn "Generated site index is missing: #{INDEX_PATH}"
+  exit 1
+end
+
+registry = YAML.safe_load(
+  REGISTRY_PATH.read(encoding: "UTF-8"),
+  permitted_classes: [Date, Time],
+  permitted_symbols: [],
+  aliases: true
+)
+
+html = INDEX_PATH.read(encoding: "UTF-8")
+nav_match = html.match(/<nav\b[^>]*\bid=["']site-nav["'][^>]*>(.*?)<\/nav>/mi)
+
+unless nav_match
+  warn "Generated home page does not contain #site-nav"
+  exit 1
+end
+
+nav_html = nav_match[1]
+errors = []
+
+publication_urls = registry.fetch("works").flat_map do |work|
+  work.fetch("editions").map { |edition| edition.fetch("url") }
+end
+
+publication_urls.each do |url|
+  hrefs = [url, "#{url}/"].uniq
+  if hrefs.any? { |href| nav_html.match?(/href=["']#{Regexp.escape(href)}["']/) }
+    errors << "canonical publication leaked into the global sidebar: #{url}"
+  end
+end
+
+required_hubs = %w[
+  /thinking/essays
+  /thinking/research-notes
+  /thinking/reading-notes
+  /thinking/translations
+  /building/publications
+  /human-transformation/publications
+]
+
+required_hubs.each do |url|
+  hrefs = [url, "#{url}/"].uniq
+  unless hrefs.any? { |href| nav_html.match?(/href=["']#{Regexp.escape(href)}["']/) }
+    errors << "required publication hub is missing from the global sidebar: #{url}"
+  end
+end
+
+if errors.empty?
+  puts "Publication navigation validation passed: #{publication_urls.length} canonical editions hidden, #{required_hubs.length} hubs visible"
+  exit 0
+end
+
+warn "Publication navigation validation failed:"
+errors.each { |error| warn "- #{error}" }
+exit 1

--- a/scripts/validate_publications.rb
+++ b/scripts/validate_publications.rb
@@ -1,0 +1,218 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "pathname"
+require "yaml"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+REGISTRY_PATH = ROOT.join("_data/publications.yml")
+
+CONTENT_DIRECTORIES = {
+  "essay" => ROOT.join("docs/thinking/essays"),
+  "research-note" => ROOT.join("docs/thinking/research-notes"),
+  "reading-note" => ROOT.join("docs/thinking/reading-notes"),
+  "translation" => ROOT.join("docs/thinking/translations")
+}.freeze
+
+VALID_BODIES = %w[building human-transformation].freeze
+VALID_THEMES = %w[
+  software-ai-agent-systems
+  entrepreneurship-company-building
+  systems-operations-decision-making
+  project-reflections-social-impact
+  learning-memory-language
+  leadership-identity-coordination
+  relationships-acceptance
+  philosophy-worldview
+].freeze
+
+class Validation
+  def initialize
+    @errors = []
+  end
+
+  def check(condition, message)
+    @errors << message unless condition
+  end
+
+  def finish!(summary)
+    if @errors.empty?
+      puts "Publication registry validation passed: #{summary}"
+      return
+    end
+
+    warn "Publication registry validation failed:"
+    @errors.each { |error| warn "- #{error}" }
+    exit 1
+  end
+end
+
+def load_yaml(path)
+  YAML.safe_load(
+    path.read(encoding: "UTF-8"),
+    permitted_classes: [Date, Time],
+    permitted_symbols: [],
+    aliases: true
+  )
+rescue Psych::SyntaxError => e
+  warn "Invalid YAML in #{path.relative_path_from(ROOT)}: #{e.message}"
+  exit 1
+end
+
+def front_matter(path)
+  text = path.read(encoding: "UTF-8")
+  match = text.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  return nil unless match
+
+  YAML.safe_load(
+    match[1],
+    permitted_classes: [Date, Time],
+    permitted_symbols: [],
+    aliases: true
+  ) || {}
+rescue Psych::SyntaxError => e
+  warn "Invalid front matter in #{path.relative_path_from(ROOT)}: #{e.message}"
+  exit 1
+end
+
+validation = Validation.new
+registry = load_yaml(REGISTRY_PATH)
+
+validation.check(registry.is_a?(Hash), "_data/publications.yml must contain a mapping")
+works = registry.is_a?(Hash) ? registry["works"] : nil
+validation.check(works.is_a?(Array), "_data/publications.yml must contain a works array")
+works = [] unless works.is_a?(Array)
+
+registry_ids = []
+registry_editions = []
+
+works.each_with_index do |work, work_index|
+  prefix = "works[#{work_index}]"
+  validation.check(work.is_a?(Hash), "#{prefix} must be a mapping")
+  next unless work.is_a?(Hash)
+
+  id = work["id"]
+  content_type = work["content_type"]
+  primary_body = work["primary_body"]
+  bodies = work["bodies_of_work"]
+  themes = work["themes"]
+  editions = work["editions"]
+
+  validation.check(id.is_a?(String) && !id.empty?, "#{prefix}.id must be a non-empty string")
+  registry_ids << id if id
+  validation.check(CONTENT_DIRECTORIES.key?(content_type), "#{prefix}.content_type is unsupported: #{content_type.inspect}")
+  validation.check(bodies.is_a?(Array) && !bodies.empty?, "#{prefix}.bodies_of_work must be a non-empty array")
+  validation.check(bodies.is_a?(Array) && bodies.all? { |body| VALID_BODIES.include?(body) }, "#{prefix}.bodies_of_work contains an unsupported body")
+  validation.check(bodies.is_a?(Array) && bodies.include?(primary_body), "#{prefix}.primary_body must appear in bodies_of_work")
+  validation.check(themes.is_a?(Array) && !themes.empty?, "#{prefix}.themes must be a non-empty array")
+  validation.check(themes.is_a?(Array) && themes.all? { |theme| VALID_THEMES.include?(theme) }, "#{prefix}.themes contains an unsupported theme")
+  validation.check(editions.is_a?(Array) && !editions.empty?, "#{prefix}.editions must be a non-empty array")
+
+  if editions.is_a?(Array) && editions.length > 1
+    key = work["translation_key"]
+    validation.check(key.is_a?(String) && !key.empty?, "#{prefix} has multiple editions but no translation_key")
+  end
+
+  next unless editions.is_a?(Array)
+
+  editions.each_with_index do |edition, edition_index|
+    edition_prefix = "#{prefix}.editions[#{edition_index}]"
+    validation.check(edition.is_a?(Hash), "#{edition_prefix} must be a mapping")
+    next unless edition.is_a?(Hash)
+
+    %w[lang label title url].each do |field|
+      value = edition[field]
+      validation.check(value.is_a?(String) && !value.empty?, "#{edition_prefix}.#{field} must be a non-empty string")
+    end
+
+    url = edition["url"]
+    validation.check(url.nil? || url.start_with?("/"), "#{edition_prefix}.url must be root-relative")
+    registry_editions << {
+      "work_id" => id,
+      "content_type" => content_type,
+      "translation_key" => work["translation_key"],
+      "url" => url
+    }
+  end
+end
+
+registry_ids.compact.group_by(&:itself).each do |id, matches|
+  validation.check(matches.length == 1, "duplicate registry work id: #{id}")
+end
+
+registry_editions.map { |edition| edition["url"] }.compact.group_by(&:itself).each do |url, matches|
+  validation.check(matches.length == 1, "duplicate registry edition URL: #{url}")
+end
+
+published_pages = []
+CONTENT_DIRECTORIES.each do |content_type, directory|
+  validation.check(directory.directory?, "missing canonical content directory: #{directory.relative_path_from(ROOT)}")
+  next unless directory.directory?
+
+  directory.glob("*.md").sort.each do |path|
+    next if path.basename.to_s == "index.md"
+
+    metadata = front_matter(path)
+    validation.check(metadata.is_a?(Hash), "#{path.relative_path_from(ROOT)} must contain YAML front matter")
+    next unless metadata.is_a?(Hash)
+
+    url = metadata["permalink"]
+    validation.check(url.is_a?(String) && url.start_with?("/"), "#{path.relative_path_from(ROOT)} must define a root-relative permalink")
+    published_pages << {
+      "path" => path.relative_path_from(ROOT).to_s,
+      "content_type" => content_type,
+      "url" => url,
+      "translation_key" => metadata["translation_key"]
+    }
+  end
+end
+
+published_pages.map { |page| page["url"] }.compact.group_by(&:itself).each do |url, matches|
+  validation.check(matches.length == 1, "duplicate canonical page permalink in publication directories: #{url}")
+end
+
+registered_by_url = registry_editions.each_with_object({}) do |edition, result|
+  result[edition["url"]] = edition if edition["url"]
+end
+published_by_url = published_pages.each_with_object({}) do |page, result|
+  result[page["url"]] = page if page["url"]
+end
+
+(published_by_url.keys - registered_by_url.keys).sort.each do |url|
+  page = published_by_url[url]
+  validation.check(false, "unregistered canonical publication: #{page['path']} (#{url})")
+end
+
+(registered_by_url.keys - published_by_url.keys).sort.each do |url|
+  edition = registered_by_url[url]
+  validation.check(false, "registry URL does not resolve to a canonical publication file: #{edition['work_id']} (#{url})")
+end
+
+(published_by_url.keys & registered_by_url.keys).each do |url|
+  page = published_by_url[url]
+  edition = registered_by_url[url]
+  validation.check(
+    page["content_type"] == edition["content_type"],
+    "content type mismatch for #{url}: directory=#{page['content_type']} registry=#{edition['content_type']}"
+  )
+
+  key = edition["translation_key"]
+  next unless key
+
+  validation.check(
+    page["translation_key"] == key,
+    "translation_key mismatch for #{url}: page=#{page['translation_key'].inspect} registry=#{key.inspect}"
+  )
+end
+
+VALID_BODIES.each do |body|
+  validation.check(works.any? { |work| Array(work["bodies_of_work"]).include?(body) }, "controlled body has no works: #{body}")
+end
+
+VALID_THEMES.each do |theme|
+  validation.check(works.any? { |work| Array(work["themes"]).include?(theme) }, "controlled theme has no works: #{theme}")
+end
+
+counts = works.group_by { |work| work["content_type"] }.transform_values(&:length).sort.to_h
+validation.finish!("#{works.length} works, #{registry_editions.length} editions, #{published_pages.length} canonical pages, types=#{counts}")


### PR DESCRIPTION
## Summary

This PR implements a two-axis publication architecture across okbayat.com:

1. **Content type determines the canonical home** — Essay, Research Note, Reading Note, Translation, Project Record, Program Record, or Experiment Report.
2. **Body of work and theme determine discovery** — Building, Human Transformation, Vocora, K2Quant, and focused thematic groupings link to the same canonical pages without duplicating them.

## What changed

### Canonical publication registry

Adds `_data/publications.yml` as the machine-readable taxonomy for every current canonical Essay, Research Note, Reading Note, and Translation.

The registry contains:

- 20 conceptual works;
- 21 language editions;
- one stable ID per conceptual work;
- unique canonical URLs for every edition;
- controlled `content_type`, `primary_body`, `bodies_of_work`, `themes`, and project/program relationships.

Persian and English versions of **Acceptance Before Change** are represented as one conceptual work with two editions rather than two unrelated archive entries.

The complete inventory also surfaced and classified two Research Notes that were absent from the former index: **هنر و روابط پنهان یک گروه** and **پروتکل ژورنال‌نویسی**.

### Thinking indexes

Updates:

- `Thinking` to explain canonical type versus topical discovery;
- `Essays` to browse by body of work and theme;
- `Research Notes` to group notes by primary body of work;
- `Reading Notes` to group source-specific notes by primary relevance;
- `Translations` to list attributed work from the registry.

### Building publication lens

Adds `Building → Publications & Notes` with curated sections for:

- Software, AI & Agent Systems;
- Entrepreneurship & Company Building;
- Systems, Operations & Decision-Making;
- Project Reflections & Social Impact;
- Learning Technology.

It also updates the Building overview and adds registry-backed related writing to K2Quant.

### Human Transformation and Vocora

Rebuilds the Human Transformation and Vocora publication indexes from the same registry so they no longer maintain independent hard-coded classifications that can drift apart.

Human Transformation is organized around:

- Relationships, Acceptance & Completion;
- Leadership, Identity & Coordination;
- Learning, Memory & Language;
- Philosophy, Worldview & Context.

### Navigation and discovery

- Adds `Publications & Notes` as the first child under Building.
- Moves K2Quant, Vocora, Projects, and Experiments one position later without changing their URLs.
- Adds both publication lenses to Home and Start Here.
- Keeps all article pages and stable canonical URLs unchanged.
- Keeps the four canonical type hubs visible under Thinking.
- Excludes all registered publication editions from sidebar children—even when an older page explicitly opted into navigation—while preserving access through type indexes, topical indexes, internal links, search, and the theme's `all` navigation mode.
- Prevents empty sidebar expanders by filtering publication children before child counts are calculated.

### Editorial guide

Updates the canonical README with:

- the two-axis architecture;
- the registry schema and controlled vocabulary;
- rules for cross-listing without duplication;
- bilingual conceptual-work grouping;
- the Building publishing model;
- taxonomy validation and maintenance requirements;
- a rule against splitting Essays into separate technical, startup, and human canonical archives.

### Deterministic validation

Adds `scripts/validate_publications.rb`, `scripts/validate_publication_navigation.rb`, and dedicated CI gates that verify:

- every canonical publication file is registered exactly once;
- every registry URL resolves to a canonical publication file;
- work IDs and edition URLs are unique;
- registry content types match canonical directories;
- bilingual editions share one conceptual entry and the expected `translation_key`;
- bodies and themes use the controlled vocabulary;
- unsupported, missing, or orphaned publications fail CI;
- every canonical publication edition is absent from the rendered global sidebar;
- Essays, Research Notes, Reading Notes, Translations, Building Publications, and Human Transformation Publications remain visible as durable hubs.

Registry diagnostics are retained as a short workflow artifact only when validation fails.

## Content classification covered

The registry classifies every current canonical written work in these sections:

- 3 conceptual Essays / 4 language editions;
- 9 Research Notes;
- 7 Reading Notes;
- 1 Translation.

Cross-disciplinary works may appear in both Building and Human Transformation while retaining one canonical page. For example, *The Infinite Game* informs company-building and leadership; Vocora research notes inform both product design and human learning.

## URL policy

No canonical article URL changes in this PR.

The existing translation **“مغز چگونه الگوهای زبان را دنبال می‌کند”** remains physically and editorially under Translations while retaining its older stable `/thinking/essays/...` permalink. The registry and indexes describe its current content type without introducing URL churn or a duplicate page.

## Validation

The branch has 21 intended changed files and is based on the latest `main` with no divergence behind the base branch.

The pull-request workflow covers:

- publication registry completeness and taxonomy integrity;
- YAML and front-matter compatibility through Jekyll builds;
- Liquid rendering of registry-backed indexes;
- rendered sidebar exclusions and required hub visibility;
- GitHub Pages build compatibility;
- HTML validation;
- CSS and JavaScript tests;
- the repository's Jekyll version, operating-system, and Ruby-version build matrix.

The PR remains draft for human review before merge.