### PR TITLE
Restore article submenus in the sidebar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,33 +15,6 @@ defaults:
     values:
       layout: "default"
 
-  # Keep canonical article pages discoverable through their type index, topical
-  # indexes, internal links, and search without crowding the global sidebar.
-  # The four section indexes explicitly opt back in with `nav_exclude: false`.
-  - scope:
-      path: "docs/thinking/essays"
-      type: "pages"
-    values:
-      nav_exclude: true
-
-  - scope:
-      path: "docs/thinking/research-notes"
-      type: "pages"
-    values:
-      nav_exclude: true
-
-  - scope:
-      path: "docs/thinking/reading-notes"
-      type: "pages"
-    values:
-      nav_exclude: true
-
-  - scope:
-      path: "docs/thinking/translations"
-      type: "pages"
-    values:
-      nav_exclude: true
-
   # Keep detailed legacy material accessible through its section hub and search
   # without allowing every course, concept, cohort, or source page to crowd the
   # global sidebar. Section index pages explicitly opt back in with

--- a/_includes/components/nav/children.html
+++ b/_includes/components/nav/children.html
@@ -1,12 +1,10 @@
 {%- comment -%}
   Include as: {%- include components/nav/children.html node=node ancestors=title_array all=bool -%}
-  Depends on: include.node, include.ancestors, include.all, nav_parenthood,
-  nav_top_node_titles, site.data.publications.
+  Depends on: include.node, include.ancestors, include.all, nav_parenthood, nav_top_node_titles.
   Includes: components/nav/sorted.html.
   Assigns to: nav_children.
   Overwrites:
-    nav_candidates, nav_child, nav_child_ok, nav_child_is_publication,
-    nav_publication_work, nav_publication_edition.
+    nav_candidates, nav_child, nav_child_ok.
 {%- endcomment -%}
 
 {%- assign nav_children = "" | split: "" -%}
@@ -18,24 +16,9 @@
 
   {%- for nav_child in nav_candidates -%}
     {%- assign nav_child_ok = true -%}
-    {%- assign nav_child_is_publication = false -%}
 
-    {%- if include.all != true -%}
-      {%- for nav_publication_work in site.data.publications.works -%}
-        {%- for nav_publication_edition in nav_publication_work.editions -%}
-          {%- if nav_publication_edition.url == nav_child.url -%}
-            {%- assign nav_child_is_publication = true -%}
-            {%- break -%}
-          {%- endif -%}
-        {%- endfor -%}
-        {%- if nav_child_is_publication -%}
-          {%- break -%}
-        {%- endif -%}
-      {%- endfor -%}
-
-      {%- if nav_child.nav_exclude == true or nav_child_is_publication -%}
-        {%- assign nav_child_ok = false -%}
-      {%- endif -%}
+    {%- if include.all != true and nav_child.nav_exclude == true -%}
+      {%- assign nav_child_ok = false -%}
     {%- endif -%}
 
     {%- if nav_child.grand_parent and nav_child.grand_parent != include.node.parent -%}

--- a/scripts/validate_publication_navigation.rb
+++ b/scripts/validate_publication_navigation.rb
@@ -39,8 +39,8 @@ end
 
 publication_urls.each do |url|
   hrefs = [url, "#{url}/"].uniq
-  if hrefs.any? { |href| nav_html.match?(/href=["']#{Regexp.escape(href)}["']/) }
-    errors << "canonical publication leaked into the global sidebar: #{url}"
+  unless hrefs.any? { |href| nav_html.match?(/href=["']#{Regexp.escape(href)}["']/) }
+    errors << "canonical publication is missing from its sidebar submenu: #{url}"
   end
 end
 
@@ -61,7 +61,7 @@ required_hubs.each do |url|
 end
 
 if errors.empty?
-  puts "Publication navigation validation passed: #{publication_urls.length} canonical editions hidden, #{required_hubs.length} hubs visible"
+  puts "Publication navigation validation passed: #{publication_urls.length} canonical editions visible in submenus, #{required_hubs.length} hubs visible"
   exit 0
 end
 


### PR DESCRIPTION
## Summary

Restores canonical Essays, Research Notes, Reading Notes, and Translations as children of their type hubs in the global sidebar.

## Root cause

PR #15 introduced two independent publication-hiding mechanisms:

1. `_config.yml` applied `nav_exclude: true` by default to every page under the four Thinking publication directories.
2. `_includes/components/nav/children.html` separately removed every URL present in `_data/publications.yml`, even when a page explicitly declared `nav_exclude: false`.

The second filter is why the Agent Skills essay disappeared despite its front matter containing `nav_exclude: false`.

## What changed

- removes the directory-wide `nav_exclude: true` defaults for Essays, Research Notes, Reading Notes, and Translations;
- removes the registry-specific child suppression from the sidebar renderer;
- preserves ordinary page-level `nav_exclude: true` behavior for intentionally hidden pages;
- preserves the taxonomy registry, grouped publication indexes, bilingual navigation, canonical URLs, and topical discovery pages;
- updates the generated-navigation validation so CI now requires all registered publication editions to appear in their sidebar submenus while keeping the six durable publication hubs visible.

## Expected behavior

- `Thinking → Essays` expands to show its articles;
- `Thinking → Research Notes` expands to show its notes;
- `Thinking → Reading Notes` expands to show its notes;
- `Thinking → Translations` expands to show its translations;
- paired English/Persian pages retain the existing primary-link plus `FA` switch behavior;
- pages that explicitly set `nav_exclude: true` remain hidden;
- no empty expander is created for parents whose only children are intentionally excluded.

## Validation

The complete PR workflow passed:

- all registered publication URLs are present in generated `#site-nav`;
- the six publication hubs remain present;
- publication registry validation passes;
- Jekyll 3.9 and 4.3 builds pass across the repository's Ruby and OS matrix;
- the GitHub Pages build passes;
- generated HTML and publication navigation validation pass;
- CSS and JavaScript tests pass.

The change is limited to three files and is based directly on the current `main` branch.