### PR TITLE
Fix code-block rendering in the phase-oriented skills essay

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -155,12 +155,12 @@ plugins:
   - jekyll-include-cache
   - jekyll-sitemap
 
+markdown: kramdown
 kramdown:
+  input: GFM
   syntax_highlighter_opts:
     block:
       line_numbers: false
-
-markdown: MyCustomProcessor
 
 compress_html:
   clippings: all


### PR DESCRIPTION
## Summary

Fixes the unreadable code and diagram sections in **“Designing Large Agent Skills as Deterministic, Phase-Oriented Systems.”**

## Root cause

The essay uses standard GitHub-flavored fenced code blocks such as ` ```text `, ` ```yaml `, ` ```json `, and ` ```ts `. The site was configured to use `MyCustomProcessor` without the GFM parser, so those fences were interpreted as inline code. As a result:

- the language identifier appeared as visible text;
- indentation and line breaks were collapsed;
- YAML lists and nested objects became prose-like lines;
- ASCII diagrams and directory trees became unreadable;
- all 13 fenced examples on the page were affected.

## What changed

- switches the configured Markdown processor to Jekyll’s supported `kramdown` processor;
- enables the GFM input parser so backtick code fences and their language identifiers are parsed correctly;
- keeps the existing Rouge syntax-highlighting options unchanged.

The article content itself is unchanged. This fixes the rendering at the parser level rather than rewriting every example into a site-specific format.

## Expected result

The full essay should preserve line breaks, indentation, nested YAML/JSON structure, TypeScript formatting, the phase graph, the directory tree, and the copy-code behavior.

## Validation

- branch is one commit ahead of `main` and zero behind;
- the diff is limited to four lines in `_config.yml`;
- the complete site CI and generated HTML checks should pass before merge.