### PR TITLE
Fix duplicate numbering in the migration TOC

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -34,6 +34,14 @@
   }
 }
 
+// The migration headings already contain their numeric step labels. Suppress
+// the theme's generated nested counters in this TOC branch so it does not
+// render combinations such as `1. a1.` before each step.
+#markdown-toc a[href="#a-practical-migration-path"] ~ ol li::before {
+  content: none;
+  counter-increment: none;
+}
+
 .footnotes {
   font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary

Fixes the duplicate `1. a1.`-style labels under **A practical migration path** in the generated table of contents.

## Root cause

The migration headings already include explicit numeric step labels (`1.` through `10.`). The generated Kramdown table of contents renders those headings inside a nested ordered list, while Just the Docs adds lower-alpha counters to nested list items. Both numbering systems therefore appeared together.

## What changed

- keeps the explicit numeric step labels because they are part of the migration sequence and also appear in the article headings;
- suppresses the theme-generated nested counters only for the `A practical migration path` branch of the table of contents;
- preserves the top-level table-of-contents numbering and leaves every other table-of-contents branch unchanged.

## Validation

- branch is one commit ahead of `main` and zero behind;
- the diff is limited to eight SCSS lines in `_sass/custom/custom.scss`;
- CI should verify SCSS formatting, Jekyll builds, and generated HTML.