### PR TITLE
Make custom Markdown syntax compatible with GFM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
         with:
           path: tmp/.htmlproofer
           key: ${{ runner.os }}-htmlproofer
+      - name: Validate custom Markdown processor
+        run: bundle exec ruby scripts/validate_custom_markdown_processor.rb
       - name: Build Site
         run: bundle exec jekyll build
       - name: Validate publication navigation

--- a/_config.yml
+++ b/_config.yml
@@ -155,7 +155,7 @@ plugins:
   - jekyll-include-cache
   - jekyll-sitemap
 
-markdown: kramdown
+markdown: MyCustomProcessor
 kramdown:
   input: GFM
   syntax_highlighter_opts:

--- a/_plugins/my_plugin.rb
+++ b/_plugins/my_plugin.rb
@@ -1,68 +1,156 @@
 class Jekyll::Converters::Markdown::MyCustomProcessor
+  FENCED_CODE_BLOCK = /
+    ^[ ]{0,3}(?<fence>`{3,}|~{3,})[^\n]*\n
+    .*?
+    ^[ ]{0,3}\k<fence>[ \t]*$
+  /mx.freeze
+
+  AUDIO_BLOCK = /
+    ^[ ]{0,3}```audio[ \t]*\n
+    (.*?)
+    ^[ ]{0,3}```[ \t]*$
+  /mx.freeze
+
+  PROTECTED_CODE_BLOCK = "\u0000OKBAYAT_CODE_BLOCK_%d\u0000".freeze
+
   def initialize(config)
-    require 'kramdown'
-    require 'yaml'
-    require 'liquid'
+    require "kramdown"
+    require "kramdown-parser-gfm"
+    require "yaml"
+    require "liquid"
 
     @config = config
-
-  rescue LoadError
-    STDERR.puts 'You are missing a library required for Markdown. Please run:'
-    STDERR.puts '  $ [sudo] gem install funky_markdown'
-    raise FatalException.new("Missing dependency: funky_markdown")
+    @markdown_options = build_markdown_options
+  rescue LoadError => error
+    warn "A library required by the custom Markdown processor is missing."
+    warn "Run `bundle install` and try again."
+    raise Jekyll::Errors::FatalException, "Missing Markdown dependency: #{error.message}"
   end
 
   def convert(content)
+    markdown = content.dup
+    protected_code_blocks = protect_fenced_code_blocks!(markdown)
 
-    # تبدیل به یک رشته قابل تغییر با استفاده از `dup`
-    non_frozen_string = content.dup
+    process_audio_blocks!(markdown)
+    process_component_includes!(markdown)
+    process_custom_spans!(markdown)
 
-    # Process audio block for YAML content
-    non_frozen_string.gsub!(/```audio\s+([\s\S]+?)\s+```/) do
-      yaml_content = $1.strip
-      audio_data = YAML.load(yaml_content)
+    restore_fenced_code_blocks!(markdown, protected_code_blocks)
+
+    html = render_markdown(markdown)
+    html.gsub!("&lt;p&gt;</p>", "")
+
+    # Process Liquid tags after Markdown so generated component includes can run.
+    Liquid::Template.parse(html).render(
+      {},
+      registers: { site: Jekyll.sites.first }
+    )
+  end
+
+  private
+
+  def build_markdown_options
+    configured_options = @config.fetch("kramdown", {})
+    options = deep_symbolize_keys(configured_options)
+
+    # The custom syntax is expanded before Markdown parsing. Keeping GFM enabled
+    # here preserves fenced code blocks, tables, task lists, and other GFM input
+    # while preventing the custom `|` separator from being interpreted as a table.
+    options[:input] = "GFM"
+    options
+  end
+
+  def deep_symbolize_keys(value)
+    case value
+    when Hash
+      value.each_with_object({}) do |(key, nested_value), result|
+        result[key.to_sym] = deep_symbolize_keys(nested_value)
+      end
+    when Array
+      value.map { |nested_value| deep_symbolize_keys(nested_value) }
+    else
+      value
+    end
+  end
+
+  def render_markdown(content)
+    Kramdown::Document.new(content, @markdown_options).to_html
+  end
+
+  def protect_fenced_code_blocks!(markdown)
+    protected_blocks = []
+
+    markdown.gsub!(FENCED_CODE_BLOCK) do |block|
+      opening_line = block.lines.first.to_s
+
+      # Audio fences are intentional site syntax and must remain available to
+      # the audio-block transformation below.
+      if opening_line.match?(/\A[ ]{0,3}`{3,}audio(?:[ \t]|$)/)
+        block
+      else
+        token = format(PROTECTED_CODE_BLOCK, protected_blocks.length)
+        protected_blocks << block
+        token
+      end
+    end
+
+    protected_blocks
+  end
+
+  def restore_fenced_code_blocks!(markdown, protected_blocks)
+    protected_blocks.each_with_index do |block, index|
+      markdown.sub!(format(PROTECTED_CODE_BLOCK, index), block)
+    end
+  end
+
+  def process_audio_blocks!(markdown)
+    markdown.gsub!(AUDIO_BLOCK) do
+      yaml_content = Regexp.last_match(1).strip
+      audio_data = YAML.safe_load(yaml_content, aliases: false)
 
       unless audio_data.is_a?(Hash)
         raise "YAML content in audio block did not parse as a Hash: #{yaml_content}"
       end
 
-      # Build the include tag for audio component
-      # include_tag = "<p></p>"
       include_tag = "{% include components/audio.html"
       audio_data.each do |key, value|
         include_tag += " #{key}=&#39;#{value}&#39;"
       end
-      include_tag += " %} <p>"
-
-      include_tag
+      include_tag + " %} <p>"
     end
+  end
 
-    # Find the Markdown file and replace the placeholder with compiled content
-    non_frozen_string.gsub!(/\{\s*([a-zA-Z0-9_\.\-]+\.md)\s*\|\s*component\s*\}/) do |match|
-      filename = './_includes/components/' + $1.strip
+  def process_component_includes!(markdown)
+    markdown.gsub!(/\{\s*([a-zA-Z0-9_.\-]+\.md)\s*\|\s*component\s*\}/) do
+      filename = File.join("_includes", "components", Regexp.last_match(1).strip)
+
       if File.exist?(filename)
-        file_content = File.read(filename)
-        Kramdown::Document.new(file_content).to_html
+        render_markdown(File.read(filename))
       else
         "<!-- File #{filename} not found -->"
       end
     end
+  end
 
-    # { bage bold new | Example text } to <span class="bage bold new">Example text</span>
-    non_frozen_string.gsub!(/\{\s*(.+?)\s*\|\s*sub\s*\}/, '<sub>\1</sub>')
-    non_frozen_string.gsub!(/\{\s*(.+?)\s*\|\s*ltr\s*\}/, '<span dir="ltr">\1</span>')
-    non_frozen_string.gsub!(/\{\s*(.+?)\s*\|\s*([a-z]+)\s*=\s*(.+?)\s*\}/, '<span \2="\3">\1</span>')
-    # non_frozen_string.gsub!(/\{\s*(.+?)\s*\|\s*(.+?)\s*\}/, '<span title="\2">\1</span>')
-    non_frozen_string.gsub!(/\{(?!:)\s*([^\}]+?)\s*\|\s*([^|]+?)\s*\}/, '<span class="\2">\1</span>')
-    non_frozen_string.gsub!(/\{(?!:)\s*([^|]+?)\s*\\\s*(.+?)\s*\}/, '<span class="\1">\2</span>')
-    
-    # ابتدا محتوای اصلی را با استفاده از تبدیل‌کننده‌ی پیش‌فرض Markdown به HTML تبدیل می‌کنیم
-    html = Kramdown::Document.new(non_frozen_string).to_html
-    html.gsub!('&lt;p&gt;</p>', '')
-    # Process Liquid tags in the HTML to allow includes
-    processed_html = Liquid::Template.parse(html).render({}, registers: { site: Jekyll.sites.first })
-    # processed_html = validate_and_fix_html(processed_html)
-    
-    processed_html
+  def process_custom_spans!(markdown)
+    markdown.gsub!(/\{\s*(.+?)\s*\|\s*sub\s*\}/, "<sub>\\1</sub>")
+    markdown.gsub!(/\{\s*(.+?)\s*\|\s*ltr\s*\}/, '<span dir="ltr">\\1</span>')
+    markdown.gsub!(
+      /\{\s*(.+?)\s*\|\s*([a-z]+)\s*=\s*(.+?)\s*\}/,
+      '<span \\2="\\3">\\1</span>'
+    )
+
+    markdown.gsub!(/\{(?!:)\s*([^}]+?)\s*\|\s*([^|]+?)\s*\}/) do
+      text = Regexp.last_match(1).strip
+      classes = Regexp.last_match(2).strip
+      %(<span class="#{classes}">#{text}</span>)
+    end
+
+    # Preserve the legacy alternate form: `{ classes \\ text }`.
+    markdown.gsub!(/\{(?!:)\s*([^|]+?)\s*\\\s*(.+?)\s*\}/) do
+      classes = Regexp.last_match(1).strip
+      text = Regexp.last_match(2).strip
+      %(<span class="#{classes}">#{text}</span>)
+    end
   end
 end

--- a/scripts/validate_custom_markdown_processor.rb
+++ b/scripts/validate_custom_markdown_processor.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+require "jekyll"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+require ROOT.join("_plugins/my_plugin").to_s
+
+config = Jekyll.configuration(
+  "source" => ROOT.to_s,
+  "destination" => ROOT.join("_site").to_s,
+  "kramdown" => {
+    "input" => "GFM",
+    "syntax_highlighter_opts" => {
+      "block" => { "line_numbers" => false }
+    }
+  }
+)
+
+converter = Jekyll::Converters::Markdown::MyCustomProcessor.new(config)
+
+source = <<~MARKDOWN
+  { Custom subtitle | fs-6 }
+
+  ```text
+  alpha | beta
+  { untouched | fs-6 }
+  ```
+
+  | A | B |
+  | --- | --- |
+  | 1 | 2 |
+MARKDOWN
+
+html = converter.convert(source)
+errors = []
+
+unless html.include?('<span class="fs-6">Custom subtitle</span>')
+  errors << "custom span syntax was not expanded before GFM parsing"
+end
+
+unless html.include?("<table>")
+  errors << "GFM table syntax was not preserved"
+end
+
+unless html.include?("alpha | beta") && html.include?("{ untouched | fs-6 }")
+  errors << "fenced code content was changed or lost"
+end
+
+if html.include?('<span class="fs-6">untouched</span>')
+  errors << "custom syntax inside a fenced code block was expanded"
+end
+
+unless html.match?(/<pre[^>]*>.*<code[^>]*>.*alpha \| beta.*<\/code>.*<\/pre>/m)
+  errors << "GFM fenced code block was not rendered as code"
+end
+
+if errors.empty?
+  puts "Custom Markdown processor validation passed: custom spans, GFM fences, and GFM tables coexist"
+  exit 0
+end
+
+warn "Custom Markdown processor validation failed:"
+errors.each { |error| warn "- #{error}" }
+warn "\nRendered HTML:\n#{html}"
+exit 1


### PR DESCRIPTION
## Summary

Restores the site's existing inline formatting syntax while keeping GitHub-flavored Markdown enabled.

The following form works again without changing article content:

```markdown
{ A reference architecture for reliable, context-efficient agent workflows | fs-6 }
```

## Root cause

PR #17 correctly enabled the GFM parser to fix fenced code blocks. However, it also bypassed the repository's existing `MyCustomProcessor` plugin. As a result, the custom `{ text | classes }` syntax reached GFM unchanged, where the pipe character could be interpreted as table syntax.

The problem was not the pipe character by itself; it was that the custom preprocessing stage was no longer running.

## What changed

- re-enables `MyCustomProcessor` as the configured Markdown processor;
- makes the processor delegate final Markdown rendering to Kramdown's GFM parser;
- preserves the established `|`-based syntax, so existing pages do not require a repository-wide migration;
- protects ordinary fenced code blocks before applying custom substitutions, so examples containing `{ ... | ... }` remain literal;
- keeps the site's custom `audio` fence behavior;
- uses the same GFM configuration for included component Markdown;
- replaces unsafe audio YAML loading with `YAML.safe_load`;
- improves the missing-dependency error so it names the actual missing library.

## Regression coverage

Adds a deterministic CI check proving that these features work together:

- `{ text | fs-6 }` renders as a styled span;
- GFM fenced code blocks remain code and their contents are not rewritten;
- ordinary GFM tables still render as tables.

## Scope

No article, URL, navigation entry, or delimiter was changed. The fix is implemented at the Markdown-processor boundary, where the conflict belongs.