### PR TITLE
Reset RTL h1 text alignment

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -50,7 +50,7 @@ works:
       - lang: en
         label: English
         title: Designing Large Agent Skills as Deterministic, Phase-Oriented Systems
-        url: /thinking/essays/phase-oriented-agent-skills
+        url: /thinking/essays/phase-oriented-agent-skills-en
 
   - id: ten-years-of-familylink
     content_type: essay

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -8,6 +8,10 @@
     font-family: IRANSans, $body-font-family;
     font-weight: 300;
 
+    h1 {
+      text-align: initial;
+    }
+
     strong {
       font-weight: 500;
     }


### PR DESCRIPTION
## What changed
- Added an `h1` rule inside `.main-content[dir="rtl"]`
- Set `text-align: initial` for RTL page-level headings
- Updated the English `phase-oriented-agent-skills` publication registry URL to its canonical `-en` permalink

## Why
The parent RTL content container justifies all descendant text, which also causes `h1` headings to be justified. This keeps paragraph justification intact while restoring the heading's natural alignment.

The publication registry still referenced the article's former URL without the language suffix, causing publication registry and navigation validation checks to fail.

## Scope
- RTL content only
- `h1` elements only
- No change to LTR pages or other heading levels
- One registry URL correction to match the existing canonical English permalink

## Validation
- `Validate publication registry`: passed
- `Validate HTML and navigation`: passed
- `Test CSS and JS`: passed
- GitHub Pages build: passed
- Full CI workflow: passed