### PR TITLE
Add automatic language switch to bilingual articles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         run: bundle exec jekyll build
       - name: Validate publication navigation
         run: ruby scripts/validate_publication_navigation.rb _site
+      - name: Validate article language switches
+        run: ruby scripts/validate_article_language_switch.rb _site
       - name: Test with Nu Validator
         uses: Cyb3r-Jak3/html5validator-action@2a593a9f2c10593cbac84791a6fc4c47e9a106c8
         with:

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -50,7 +50,7 @@ works:
       - lang: en
         label: English
         title: Designing Large Agent Skills as Deterministic, Phase-Oriented Systems
-        url: /thinking/essays/phase-oriented-agent-skills
+        url: /thinking/essays/phase-oriented-agent-skills-en
 
   - id: ten-years-of-familylink
     content_type: essay

--- a/_includes/components/article_language_switch.html
+++ b/_includes/components/article_language_switch.html
@@ -1,0 +1,40 @@
+{%- comment -%}
+  Render a compact link to the alternate-language edition of the current page.
+
+  Pair discovery intentionally follows the same filename contract as the sidebar
+  and breadcrumbs: sibling files must share a stem and end in -en.md / -fa.md.
+{%- endcomment -%}
+
+{%- assign article_language_page_path = page.path | default: "" -%}
+{%- assign article_language_page_suffix = article_language_page_path | slice: -6, 6 -%}
+{%- assign article_language_counterpart_path = nil -%}
+{%- assign article_language_label = nil -%}
+{%- assign article_language_code = nil -%}
+{%- assign article_language_accessible_label = nil -%}
+
+{%- if article_language_page_suffix == "-en.md" -%}
+  {%- assign article_language_counterpart_path = article_language_page_path | replace: "-en.md", "-fa.md" -%}
+  {%- assign article_language_label = "FA" -%}
+  {%- assign article_language_code = "fa" -%}
+  {%- assign article_language_accessible_label = "Read the Persian version" -%}
+{%- elsif article_language_page_suffix == "-fa.md" -%}
+  {%- assign article_language_counterpart_path = article_language_page_path | replace: "-fa.md", "-en.md" -%}
+  {%- assign article_language_label = "EN" -%}
+  {%- assign article_language_code = "en" -%}
+  {%- assign article_language_accessible_label = "مطالعهٔ نسخهٔ انگلیسی" -%}
+{%- endif -%}
+
+{%- if article_language_counterpart_path -%}
+  {%- assign article_language_counterpart = site.html_pages | where: "path", article_language_counterpart_path | first -%}
+  {%- if article_language_counterpart -%}
+    <a
+      class="article-language-switch"
+      href="{{ article_language_counterpart.url | relative_url }}"
+      lang="{{ article_language_code }}"
+      hreflang="{{ article_language_code }}"
+      rel="alternate"
+      aria-label="{{ article_language_accessible_label }}: {{ article_language_counterpart.title | escape }}"
+      title="{{ article_language_accessible_label }}"
+    >{{ article_language_label }}</a>
+  {%- endif -%}
+{%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,11 +22,58 @@ layout: table_wrappers
       {% include components/breadcrumbs.html %}
       <div id="main-content" class="main-content" dir="{{ page.direction | default: 'ltr' }}">
         <main>
-          {% if site.heading_anchors != false %}
-            {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
-          {% else %}
-            {{ content }}
+          {% capture rendered_content %}
+            {% if site.heading_anchors != false %}
+              {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+            {% else %}
+              {{ content }}
+            {% endif %}
+          {% endcapture %}
+
+          {% assign article_language_page_path = page.path | default: "" %}
+          {% assign article_language_page_suffix = article_language_page_path | slice: -6, 6 %}
+          {% assign article_language_counterpart_path = nil %}
+
+          {% if article_language_page_suffix == "-en.md" %}
+            {% assign article_language_counterpart_path = article_language_page_path | replace: "-en.md", "-fa.md" %}
+          {% elsif article_language_page_suffix == "-fa.md" %}
+            {% assign article_language_counterpart_path = article_language_page_path | replace: "-fa.md", "-en.md" %}
           {% endif %}
+
+          {% assign article_language_counterpart = nil %}
+          {% if article_language_counterpart_path %}
+            {% assign article_language_counterpart = site.html_pages | where: "path", article_language_counterpart_path | first %}
+          {% endif %}
+
+          {% capture article_language_switch %}{% include components/article_language_switch.html %}{% endcapture %}
+          {% assign article_language_switch = article_language_switch | strip %}
+
+          {% if article_language_counterpart and article_language_switch != "" %}
+            {% assign article_language_counterpart_url = article_language_counterpart.url | relative_url %}
+
+            {% comment %}
+              Remove the legacy, hand-authored links used by existing bilingual
+              articles. New articles should rely only on the automatic switch.
+            {% endcomment %}
+            {% capture legacy_english_language_link %}<p><span dir="ltr"><a href="{{ article_language_counterpart_url }}">English version</a></span></p>{% endcapture %}
+            {% capture legacy_persian_language_link %}<p><a href="{{ article_language_counterpart_url }}">نسخه‌ی فارسی</a></p>{% endcapture %}
+            {% assign rendered_content = rendered_content | remove: legacy_english_language_link | remove: legacy_persian_language_link %}
+
+            {% assign article_language_legacy_url = article_language_counterpart_url | replace: "-en", "" %}
+            {% if article_language_legacy_url != article_language_counterpart_url %}
+              {% capture legacy_english_language_link_without_suffix %}<p><span dir="ltr"><a href="{{ article_language_legacy_url }}">English version</a></span></p>{% endcapture %}
+              {% assign rendered_content = rendered_content | remove: legacy_english_language_link_without_suffix %}
+            {% endif %}
+
+            {% if rendered_content contains "<h1" %}
+              {% capture article_heading_open %}<div class="article-heading-row"><h1{% endcapture %}
+              {% capture article_heading_close %}</h1>{{ article_language_switch }}</div>{% endcapture %}
+              {% assign rendered_content = rendered_content | replace_first: "<h1", article_heading_open %}
+              {% assign rendered_content = rendered_content | replace_first: "</h1>", article_heading_close %}
+            {% endif %}
+          {% endif %}
+
+          {{ rendered_content }}
 
           {% if page.has_toc != false %}
             {% include components/children_nav.html %}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -122,6 +122,45 @@
   }
 }
 
+.article-heading-row {
+  display: flex;
+  align-items: baseline;
+  gap: $sp-2;
+
+  > h1 {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+.article-language-switch {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.25rem;
+  padding: 0 $sp-1;
+  direction: ltr;
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1;
+  color: $link-color;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: $body-background-color;
+  border: $border $border-color;
+  border-radius: 2px;
+
+  &:hover,
+  &:focus {
+    color: $link-color;
+    text-decoration: none;
+    background-color: $feedback-color;
+  }
+}
+
 iframe.calendar {
   width: 100%;
   height: 600px;

--- a/scripts/validate_article_language_switch.rb
+++ b/scripts/validate_article_language_switch.rb
@@ -1,0 +1,185 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "cgi"
+require "date"
+require "pathname"
+require "yaml"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+REGISTRY_PATH = ROOT.join("_data/publications.yml")
+CONTENT_ROOT = ROOT.join("docs")
+
+
+def normalize_url(url)
+  value = url.to_s
+  return "/" if value == "/"
+
+  value.sub(%r{/\z}, "")
+end
+
+
+def href_variants(url)
+  normalized = normalize_url(url)
+  [normalized, "#{normalized}/"].uniq
+end
+
+
+def href_count(html, url)
+  href_variants(url).sum do |href|
+    html.scan(/href=["']#{Regexp.escape(href)}["']/).length
+  end
+end
+
+
+def front_matter(path)
+  content = path.read(encoding: "UTF-8")
+  match = content.match(/\A(?:\uFEFF)?---\s*\r?\n(.*?)\r?\n---\s*(?:\r?\n|\z)/m)
+  raise "Missing YAML front matter: #{path}" unless match
+
+  YAML.safe_load(
+    match[1],
+    permitted_classes: [Date, Time],
+    permitted_symbols: [],
+    aliases: true
+  ) || {}
+rescue Psych::Exception => error
+  raise "Invalid YAML front matter in #{path}: #{error.message}"
+end
+
+
+def generated_page_path(site_dir, url)
+  normalized = normalize_url(url)
+  return site_dir.join("index.html") if normalized == "/"
+
+  relative = normalized.delete_prefix("/")
+  candidates = [
+    site_dir.join(relative, "index.html"),
+    site_dir.join("#{relative}.html"),
+    site_dir.join(relative)
+  ]
+
+  candidates.find(&:file?)
+end
+
+registry = YAML.safe_load(
+  REGISTRY_PATH.read(encoding: "UTF-8"),
+  permitted_classes: [Date, Time],
+  permitted_symbols: [],
+  aliases: true
+)
+
+language_paths = (
+  CONTENT_ROOT.glob("**/*-en.md") +
+  CONTENT_ROOT.glob("**/*-fa.md")
+).sort
+
+sources_by_permalink = language_paths.each_with_object({}) do |path, index|
+  permalink = front_matter(path)["permalink"]
+  next unless permalink
+
+  index[normalize_url(permalink)] = path
+end
+
+errors = []
+checked_pages = 0
+
+registry.fetch("works").each do |work|
+  editions = work.fetch("editions")
+  next unless editions.length > 1
+
+  work_id = work.fetch("id")
+  edition_urls = editions.map { |edition| normalize_url(edition.fetch("url")) }
+  source_paths = edition_urls.map { |url| sources_by_permalink[url] }
+
+  if source_paths.any?(&:nil?)
+    errors << "multi-edition work does not resolve to language-suffixed sources: #{work_id}"
+    next
+  end
+
+  english_path = source_paths.find { |path| path.basename.to_s.end_with?("-en.md") }
+  persian_path = source_paths.find { |path| path.basename.to_s.end_with?("-fa.md") }
+
+  unless english_path && persian_path
+    errors << "multi-edition work must contain one English and one Persian source: #{work_id}"
+    next
+  end
+
+  english_url = normalize_url(front_matter(english_path).fetch("permalink"))
+  persian_url = normalize_url(front_matter(persian_path).fetch("permalink"))
+
+  page_expectations = [
+    [english_url, persian_url, "FA", "fa"],
+    [persian_url, english_url, "EN", "en"]
+  ]
+
+  page_expectations.each do |current_url, counterpart_url, expected_label, expected_hreflang|
+    output_path = generated_page_path(SITE_DIR, current_url)
+
+    unless output_path
+      errors << "generated article page is missing for #{current_url}"
+      next
+    end
+
+    html = output_path.read(encoding: "UTF-8")
+    main_match = html.match(/<main\b[^>]*>(.*?)<\/main>/mi)
+
+    unless main_match
+      errors << "generated article page does not contain <main>: #{current_url}"
+      next
+    end
+
+    main_html = main_match[1]
+    switches = main_html.scan(
+      /<a\b(?=[^>]*class=["'][^"']*\barticle-language-switch\b)[^>]*>.*?<\/a>/mi
+    )
+
+    unless switches.length == 1
+      errors << "article must render exactly one language switch, found #{switches.length}: #{current_url}"
+      next
+    end
+
+    switch_html = switches.first
+    expected_href = href_variants(counterpart_url).any? do |href|
+      switch_html.match?(/\bhref=["']#{Regexp.escape(href)}["']/)
+    end
+
+    unless expected_href
+      errors << "language switch does not link to #{counterpart_url}: #{current_url}"
+    end
+
+    unless switch_html.match?(/\bhreflang=["']#{Regexp.escape(expected_hreflang)}["']/)
+      errors << "language switch must declare hreflang=#{expected_hreflang}: #{current_url}"
+    end
+
+    visible_label = CGI.unescapeHTML(switch_html.gsub(/<[^>]+>/, "")).strip
+    unless visible_label == expected_label
+      errors << "language switch label must be #{expected_label.inspect}, found #{visible_label.inspect}: #{current_url}"
+    end
+
+    heading_match = main_html.match(
+      /<div\b[^>]*class=["'][^"']*\barticle-heading-row\b[^>]*>(.*?)<\/div>/mi
+    )
+
+    unless heading_match && heading_match[1].match?(/<h1\b/i) && heading_match[1].include?(switch_html)
+      errors << "language switch must be rendered beside the first h1: #{current_url}"
+    end
+
+    counterpart_links = href_count(main_html, counterpart_url)
+    unless counterpart_links == 1
+      errors << "article must expose its counterpart exactly once, found #{counterpart_links}: #{current_url}"
+    end
+
+    checked_pages += 1
+  end
+end
+
+if errors.empty?
+  puts "Article language-switch validation passed: #{checked_pages} bilingual pages link to their counterpart once beside h1"
+  exit 0
+end
+
+warn "Article language-switch validation failed:"
+errors.each { |error| warn "- #{error}" }
+exit 1


### PR DESCRIPTION
## Summary

- Detect exact `-en.md` / `-fa.md` sibling pairs automatically.
- Render a compact `FA` or `EN` link beside the article’s first `h1`.
- Preserve RTL/LTR layout and add accessible `lang`, `hreflang`, `rel="alternate"`, labels, and hover/focus states.
- Remove existing hand-authored language links from rendered bilingual articles so readers see only the automatic switch.
- Align the phase-oriented essay registry URL with its current `-en` permalink.
- Add CI validation for placement, counterpart URLs, labels, and duplicate links.

## Pairing contract

Bilingual editions must live in the same directory and use the same stem:

- `<stem>-en.md`
- `<stem>-fa.md`

No switch is rendered when the counterpart file does not exist.

## Validation

- Added `scripts/validate_article_language_switch.rb`.
- Existing Jekyll, HTML, navigation, CSS, and JavaScript checks continue to run.