### PR TITLE
Place the article language switch inside the heading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,10 +66,12 @@ layout: table_wrappers
             {% endif %}
 
             {% if rendered_content contains "<h1" %}
-              {% capture article_heading_open %}<div class="article-heading-row"><h1{% endcapture %}
-              {% capture article_heading_close %}</h1>{{ article_language_switch }}</div>{% endcapture %}
-              {% assign rendered_content = rendered_content | replace_first: "<h1", article_heading_open %}
-              {% assign rendered_content = rendered_content | replace_first: "</h1>", article_heading_close %}
+              {% assign article_heading_parts = rendered_content | split: "<h1" %}
+              {% assign article_heading_fragment = article_heading_parts[1] %}
+              {% assign article_heading_attributes = article_heading_fragment | split: ">" | first %}
+              {% capture article_heading_open %}<h1{{ article_heading_attributes }}>{% endcapture %}
+              {% capture article_heading_open_with_switch %}{{ article_heading_open }}{{ article_language_switch }}{% endcapture %}
+              {% assign rendered_content = rendered_content | replace_first: article_heading_open, article_heading_open_with_switch %}
             {% endif %}
           {% endif %}
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -126,43 +126,14 @@
   }
 }
 
-.article-heading-row {
-  display: flex;
-  align-items: baseline;
-  gap: $sp-2;
-
-  > h1 {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-}
-
 .article-language-switch {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.75rem;
-  height: 1.25rem;
-  padding: 0 $sp-1;
+  display: inline-block;
+  margin: 0 10px;
   direction: ltr;
-  font-size: 0.625rem;
-  font-weight: 600;
-  line-height: 1;
-  color: $link-color;
-  text-align: center;
-  text-decoration: none;
+  font-size: 1rem;
+  unicode-bidi: isolate;
+  vertical-align: baseline;
   white-space: nowrap;
-  background-color: $body-background-color;
-  border: $border $border-color;
-  border-radius: 2px;
-
-  &:hover,
-  &:focus {
-    color: $link-color;
-    text-decoration: none;
-    background-color: $feedback-color;
-  }
 }
 
 iframe.calendar {

--- a/scripts/validate_article_language_switch.rb
+++ b/scripts/validate_article_language_switch.rb
@@ -158,12 +158,19 @@ registry.fetch("works").each do |work|
       errors << "language switch label must be #{expected_label.inspect}, found #{visible_label.inspect}: #{current_url}"
     end
 
-    heading_match = main_html.match(
-      /<div\b[^>]*class=["'][^"']*\barticle-heading-row\b[^>]*>(.*?)<\/div>/mi
-    )
+    heading_match = main_html.match(/<h1\b[^>]*>(.*?)<\/h1>/mi)
 
-    unless heading_match && heading_match[1].match?(/<h1\b/i) && heading_match[1].include?(switch_html)
-      errors << "language switch must be rendered beside the first h1: #{current_url}"
+    unless heading_match && heading_match[1].include?(switch_html)
+      errors << "language switch must be rendered inside the first h1: #{current_url}"
+    else
+      heading_body = heading_match[1].lstrip
+      unless heading_body.start_with?(switch_html)
+        errors << "language switch must be the first element inside the first h1: #{current_url}"
+      end
+    end
+
+    if main_html.match?(/\barticle-heading-row\b/)
+      errors << "article must not render the obsolete article-heading-row wrapper: #{current_url}"
     end
 
     counterpart_links = href_count(main_html, counterpart_url)
@@ -176,7 +183,7 @@ registry.fetch("works").each do |work|
 end
 
 if errors.empty?
-  puts "Article language-switch validation passed: #{checked_pages} bilingual pages link to their counterpart once beside h1"
+  puts "Article language-switch validation passed: #{checked_pages} bilingual pages link to their counterpart once at the start of h1"
   exit 0
 end
 


### PR DESCRIPTION
## Summary

- Move the automatic `EN` / `FA` switch from a separate flex row into the first `h1`.
- Insert it at the logical start of the heading so it remains on the first line when long titles wrap on mobile.
- Replace the boxed control styling with the lighter treatment tested in the browser: `font-size: 1rem` and `margin: 0 10px`.
- Preserve RTL/LTR behavior with bidi isolation and keep the existing accessible alternate-language link metadata.
- Update CI validation to require the switch as the first element inside the first `h1` and reject the old `article-heading-row` wrapper.

## UX decision

The logical start is preferable to the end because the control stays consistently discoverable and does not become stranded in the middle or at the end of a wrapped multi-line title. Logical positioning also places it on the right for Persian and on the left for English.

## Scope

This PR is intentionally separate from the original automatic language-switch implementation and contains only the heading-placement and styling refinement.