### PR TITLE
Move the article language switch to the end of the heading

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,12 +66,8 @@ layout: table_wrappers
             {% endif %}
 
             {% if rendered_content contains "<h1" %}
-              {% assign article_heading_parts = rendered_content | split: "<h1" %}
-              {% assign article_heading_fragment = article_heading_parts[1] %}
-              {% assign article_heading_attributes = article_heading_fragment | split: ">" | first %}
-              {% capture article_heading_open %}<h1{{ article_heading_attributes }}>{% endcapture %}
-              {% capture article_heading_open_with_switch %}{{ article_heading_open }}{{ article_language_switch }}{% endcapture %}
-              {% assign rendered_content = rendered_content | replace_first: article_heading_open, article_heading_open_with_switch %}
+              {% capture article_heading_close_with_switch %}{{ article_language_switch }}</h1>{% endcapture %}
+              {% assign rendered_content = rendered_content | replace_first: "</h1>", article_heading_close_with_switch %}
             {% endif %}
           {% endif %}
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -128,9 +128,9 @@
 
 .article-language-switch {
   display: inline-block;
-  margin: 0 10px;
   direction: ltr;
   font-size: 1rem;
+  margin: 10px;
   unicode-bidi: isolate;
   vertical-align: baseline;
   white-space: nowrap;

--- a/scripts/validate_article_language_switch.rb
+++ b/scripts/validate_article_language_switch.rb
@@ -163,9 +163,9 @@ registry.fetch("works").each do |work|
     unless heading_match && heading_match[1].include?(switch_html)
       errors << "language switch must be rendered inside the first h1: #{current_url}"
     else
-      heading_body = heading_match[1].lstrip
-      unless heading_body.start_with?(switch_html)
-        errors << "language switch must be the first element inside the first h1: #{current_url}"
+      heading_body = heading_match[1].rstrip
+      unless heading_body.end_with?(switch_html)
+        errors << "language switch must be the final element inside the first h1: #{current_url}"
       end
     end
 
@@ -183,7 +183,7 @@ registry.fetch("works").each do |work|
 end
 
 if errors.empty?
-  puts "Article language-switch validation passed: #{checked_pages} bilingual pages link to their counterpart once at the start of h1"
+  puts "Article language-switch validation passed: #{checked_pages} bilingual pages link to their counterpart once at the end of h1"
   exit 0
 end
 


### PR DESCRIPTION
## Summary

- Move the automatic `EN` / `FA` switch from the beginning to the end of the first `h1`.
- Keep the switch inside the heading element so it follows the title naturally in the reading flow.
- Set the switch styling to exactly `font-size: 1rem` and `margin: 10px`.
- Update CI validation to require the switch as the final element inside the first `h1`.

## Scope

This is a separate follow-up to the already merged heading-placement PR and contains only the requested placement, spacing, and validation changes.