### PR TITLE
Restore automatic child-page lists on parent pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
         run: ruby scripts/validate_list_and_sidebar_styles.rb
       - name: Build Site
         run: bundle exec jekyll build
+      - name: Validate automatic child-page lists
+        run: ruby scripts/validate_child_page_navigation.rb _site
       - name: Validate publication navigation
         run: ruby scripts/validate_publication_navigation.rb _site
       - name: Validate article language switches

--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -25,8 +25,12 @@
 
   {%- assign nav_children = nil -%}
 
+  {%- comment -%}
+    Match the stable beginning of the anchor instead of its complete opening tag.
+    Navigation links may contain extra attributes such as `title`.
+  {%- endcomment -%}
   {%- capture nav_list_link -%}
-  <a href="{{ page.url | relative_url }}" class="nav-list-link">
+  <a href="{{ page.url | relative_url }}" class="nav-list-link"
   {%- endcapture -%}
 
   {%- capture nav_list_simple -%}

--- a/scripts/validate_child_page_navigation.rb
+++ b/scripts/validate_child_page_navigation.rb
@@ -1,0 +1,74 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+
+
+def generated_page_path(site_dir, url)
+  normalized = url.to_s.sub(%r{\A/}, "").sub(%r{/\z}, "")
+  candidates = [
+    site_dir.join("#{normalized}.html"),
+    site_dir.join(normalized, "index.html")
+  ]
+
+  candidates.find(&:file?)
+end
+
+
+def contains_href?(html, url)
+  normalized = url.to_s.sub(%r{/\z}, "")
+  variants = [normalized, "#{normalized}/"].uniq
+
+  variants.any? do |href|
+    html.match?(/href=["']#{Regexp.escape(href)}["']/)
+  end
+end
+
+parent_url = "/thinking"
+expected_children = %w[
+  /thinking/essays
+  /thinking/research-notes
+  /thinking/reading-notes
+  /thinking/translations
+]
+
+page_path = generated_page_path(SITE_DIR, parent_url)
+
+unless page_path
+  warn "Generated parent page is missing: #{parent_url}"
+  exit 1
+end
+
+html = page_path.read(encoding: "UTF-8")
+main_match = html.match(/<main\b[^>]*>(.*?)<\/main>/mi)
+
+unless main_match
+  warn "Generated parent page does not contain a main element: #{page_path}"
+  exit 1
+end
+
+main_html = main_match[1]
+toc_match = main_html.match(
+  /<h2\b[^>]*class=["'][^"']*\btext-delta\b[^"']*["'][^>]*>\s*Table of contents\s*<\/h2>\s*<ul>(.*?)<\/ul>/mi
+)
+
+unless toc_match
+  warn "Automatic child-page table of contents is missing from #{parent_url}"
+  exit 1
+end
+
+child_list_html = toc_match[1]
+missing_children = expected_children.reject do |child_url|
+  contains_href?(child_list_html, child_url)
+end
+
+unless missing_children.empty?
+  warn "Automatic child-page table of contents is incomplete for #{parent_url}:"
+  missing_children.each { |child_url| warn "- missing child link: #{child_url}" }
+  exit 1
+end
+
+puts "Child-page navigation validation passed: #{parent_url} lists #{expected_children.length} direct children"


### PR DESCRIPTION
## Summary

- Restores the automatically generated child-page list on parent pages.
- Keeps child relationships derived from `parent`; no `has_children: true` front matter is reintroduced.
- Adds a generated-site regression check so CI fails if a representative parent page loses its automatic child list again.

## Root cause

PR #11 added a `title` attribute to sidebar navigation links so truncated titles have a native tooltip. The child-page navigation include still searched for the complete opening anchor exactly as it existed before that change:

```html
<a href="..." class="nav-list-link">
```

The rendered link is now:

```html
<a href="..." class="nav-list-link" title="...">
```

Because that exact string no longer matched, `children_nav` concluded that parent pages had no children and skipped the generated list. PR #13 fixed the same brittle assumption in breadcrumbs, but this include was left unchanged.

## Fix

Match only the stable beginning of the navigation anchor rather than the complete opening tag. This allows optional attributes such as `title` without breaking child detection and follows the approach already used by the breadcrumb implementation.

## Regression coverage

`scripts/validate_child_page_navigation.rb` inspects the generated `/thinking` page and requires its automatic `Table of contents` block to contain all four direct children:

- Essays
- Research Notes
- Reading Notes
- Translations

The check runs after the site build in the existing HTML and navigation validation job.

## Impact

Parent pages with child pages once again render the theme-generated child-page table of contents. The sidebar hierarchy, page content, URLs, and editorial structure are unchanged.

## Validation

CI run 1645 passed completely, including:

- the new automatic child-page list regression check;
- generated HTML and navigation validation;
- publication registry and publication navigation validation;
- article language-switch validation;
- Nu HTML validation;
- CSS and JavaScript tests;
- GitHub Pages build;
- the full Jekyll 3.9 / 4.3 matrix across Linux, macOS, Windows, and supported Ruby versions.

The branch is based directly on current `main`, is not behind it, and changes only the shared include, the regression script, and the CI step that runs it.