### PR TITLE
Enforce a single canonical README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,8 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Validate canonical README
+        run: ruby scripts/validate_canonical_readme.rb
       - name: Cache HTMLProofer
         id: cache-htmlproofer
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,18 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Validate canonical README
-        run: ruby scripts/validate_canonical_readme.rb
+        shell: bash
+        run: |
+          set -o pipefail
+          ruby scripts/validate_canonical_readme.rb 2>&1 | tee readme-validation.txt
+      - name: Upload canonical README diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: canonical-readme-validation
+          path: readme-validation.txt
+          if-no-files-found: error
+          retention-days: 7
       - name: Cache HTMLProofer
         id: cache-htmlproofer
         uses: actions/cache@v3

--- a/_sass/vendor/normalize.scss/README.md
+++ b/_sass/vendor/normalize.scss/README.md
@@ -1,7 +1,0 @@
-# normalize.scss
-
-Normalize.scss is an SCSS copy of [normalize.css](http://necolas.github.io/normalize.css), a customisable CSS file that makes browsers render all elements more consistently and in line with modern standards.
-
-The [normalize.scss fork](https://github.com/guerrero/normalize.scss) of [normalize.css](http://necolas.github.io/normalize.css) was archived in 2014, and has not been updated since v0.1.0.
-
-[View the normalize.css test file](http://necolas.github.io/normalize.css/latest/test.html)

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -1,3 +1,0 @@
-# Test Fixtures
-
-These files are used by Just the Docs maintainers to test *the theme itself*. **If you are using Just the Docs as a theme, you should not copy these files over.**

--- a/scripts/validate_canonical_readme.rb
+++ b/scripts/validate_canonical_readme.rb
@@ -1,0 +1,89 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+CANONICAL_README = "README.md"
+VALIDATOR_PATH = "scripts/validate_canonical_readme.rb"
+TEXT_EXTENSIONS = %w[
+  .css .html .htm .js .json .liquid .markdown .md .mjs .cjs
+  .rb .scss .text .txt .toml .xml .yaml .yml
+].freeze
+LEGACY_ARCHITECTURE_PATTERNS = {
+  "the superseded thinking-driven site description" => /thinking[\u2010-\u2015\u2212-]driven personal website/i,
+  "the superseded top-level navigation declaration" => /The main navigation of the site must include only the following sections/i,
+  "the superseded Leadership & Personal Development section" => /Leadership\s*&\s*Personal Development/i,
+  "the superseded Current Blog to Essays mapping" => /Current Blog\s*(?:→|->)\s*Essays/i,
+  "the superseded 60% Essays editorial ratio" => /60%\s*Essays/i
+}.freeze
+
+
+def tracked_files
+  output, status = Open3.capture2e("git", "-C", ROOT.to_s, "ls-files", "-z")
+  abort "Could not list tracked files:\n#{output}" unless status.success?
+
+  output.split("\0").reject(&:empty?)
+end
+
+
+def readme_path?(path)
+  File.basename(path).match?(/\AREADME(?:\..+)?\z/i)
+end
+
+
+def text_source?(path)
+  TEXT_EXTENSIONS.include?(File.extname(path).downcase)
+end
+
+files = tracked_files
+errors = []
+readmes = files.select { |path| readme_path?(path) }.sort
+
+unless readmes == [CANONICAL_README]
+  errors << "the repository must contain exactly one tracked README at #{CANONICAL_README}"
+  errors << "tracked README candidates: #{readmes.empty? ? '(none)' : readmes.join(', ')}"
+end
+
+canonical_path = ROOT.join(CANONICAL_README)
+if canonical_path.file?
+  canonical_content = canonical_path.read(encoding: "UTF-8")
+  expected_heading = "# okbayat.com — Content Architecture and Editorial Guide"
+  expected_statement = "It is the canonical guide for the site's navigation, editorial model, publication taxonomy, and maintenance rules."
+
+  errors << "#{CANONICAL_README} is missing the canonical guide heading" unless canonical_content.include?(expected_heading)
+  errors << "#{CANONICAL_README} is missing its canonical-source statement" unless canonical_content.include?(expected_statement)
+else
+  errors << "#{CANONICAL_README} does not exist"
+end
+
+legacy_matches = []
+files.each do |relative_path|
+  next if relative_path == VALIDATOR_PATH
+  next unless text_source?(relative_path)
+
+  absolute_path = ROOT.join(relative_path)
+  next unless absolute_path.file?
+
+  source = absolute_path.read(encoding: "UTF-8")
+  LEGACY_ARCHITECTURE_PATTERNS.each do |description, pattern|
+    legacy_matches << "#{relative_path}: #{description}" if source.match?(pattern)
+  end
+rescue ArgumentError, Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+  next
+end
+
+unless legacy_matches.empty?
+  errors << "legacy architecture wording remains in tracked source files"
+  errors.concat(legacy_matches.sort)
+end
+
+if errors.empty?
+  puts "Canonical README validation passed: README.md is the sole tracked README and no legacy architecture guide remains"
+  exit 0
+end
+
+warn "Canonical README validation failed:"
+errors.each { |error| warn "- #{error}" }
+exit 1


### PR DESCRIPTION
## Summary

- remove `_sass/vendor/normalize.scss/README.md`
- remove `fixtures/README.md`
- keep the root `README.md` as the repository's sole canonical architecture guide
- add a tracked-file validation that rejects any additional README file
- reject known fingerprints from the superseded uploaded architecture guide if they are copied into tracked source files
- run the consistency check in CI and upload diagnostics on failure

## Findings

The repository still contained three tracked README files:

1. `README.md` — the current canonical content architecture and editorial guide
2. `_sass/vendor/normalize.scss/README.md` — vendor background text; attribution remains in the `normalize.scss` source header
3. `fixtures/README.md` — copied Just the Docs fixture boilerplate that explicitly says it should not be copied into sites using the theme

The older README uploaded outside GitHub is not tracked in this repository and is not treated as a source of truth. The new validation also blocks its legacy architecture wording from being reintroduced into tracked source files.

## Scope

This PR does **not** change navigation order, menu labels, page hierarchy, or site content.

## Validation

- canonical README validation passes with exactly one tracked README
- existing publication validation passes
- existing site build, navigation, language-switch, HTML, CSS, and JavaScript checks remain in CI