### PR TITLE
Fix profile photo rendering and add it to Resume

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
         run: ruby scripts/validate_list_and_sidebar_styles.rb
       - name: Build Site
         run: bundle exec jekyll build
+      - name: Validate profile photos
+        run: ruby scripts/validate_profile_photos.rb _site
       - name: Validate automatic child-page lists
         run: ruby scripts/validate_child_page_navigation.rb _site
       - name: Validate publication navigation

--- a/_includes/components/profile_photo.html
+++ b/_includes/components/profile_photo.html
@@ -2,20 +2,7 @@
 {%- assign profile_photo_alt = include.alt | default: "Portrait of Mohammad Bayat" -%}
 
 {%- if include.link -%}
-<a
-  class="profile-photo-link profile-photo-link-{{ profile_photo_variant }}"
-  href="{{ include.link | relative_url }}"
-  aria-label="Read Mohammad Bayat's biography"
->
-{%- endif -%}
-<img
-  class="profile-photo profile-photo-{{ profile_photo_variant }}"
-  src="{{ '/assets/images/Mohammad-Bayat-Avatar.jpg' | relative_url }}"
-  alt="{{ profile_photo_alt }}"
-  width="721"
-  height="721"
-  decoding="async"
->
-{%- if include.link -%}
-</a>
+<a class="profile-photo-link profile-photo-link-{{ profile_photo_variant }}" href="{{ include.link | relative_url }}" aria-label="Read Mohammad Bayat's biography"><img class="profile-photo profile-photo-{{ profile_photo_variant }}" src="{{ '/assets/images/Mohammad-Bayat-Avatar.jpg' | relative_url }}" alt="{{ profile_photo_alt | escape }}" width="721" height="721" decoding="async"></a>
+{%- else -%}
+<img class="profile-photo profile-photo-{{ profile_photo_variant }}" src="{{ '/assets/images/Mohammad-Bayat-Avatar.jpg' | relative_url }}" alt="{{ profile_photo_alt | escape }}" width="721" height="721" decoding="async">
 {%- endif -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,6 +71,17 @@ layout: table_wrappers
             {% endif %}
           {% endif %}
 
+          {% comment %}
+            Insert the Resume portrait after Markdown conversion. This avoids
+            routing raw multi-line HTML through the custom Markdown processor.
+          {% endcomment %}
+          {% if page.url == "/about/resume" and rendered_content contains "<h1" %}
+            {% capture resume_profile_photo %}{% include components/profile_photo.html variant="resume" %}{% endcapture %}
+            {% assign resume_profile_photo = resume_profile_photo | strip %}
+            {% capture resume_heading_close_with_photo %}</h1>{{ resume_profile_photo }}{% endcapture %}
+            {% assign rendered_content = rendered_content | replace_first: "</h1>", resume_heading_close_with_photo %}
+          {% endif %}
+
           {{ rendered_content }}
 
           {% if page.has_toc != false %}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -165,6 +165,11 @@
   margin: 0 auto $sp-5;
 }
 
+.profile-photo-resume {
+  width: 10rem;
+  margin: 0 auto $sp-5;
+}
+
 @include mq(md) {
   .profile-photo-link-home {
     float: right;
@@ -175,6 +180,12 @@
   .profile-photo-biography {
     float: right;
     width: 14rem;
+    margin: 0 0 $sp-4 $sp-5;
+  }
+
+  .profile-photo-resume {
+    float: right;
+    width: 11rem;
     margin: 0 0 $sp-4 $sp-5;
   }
 }

--- a/scripts/validate_profile_photos.rb
+++ b/scripts/validate_profile_photos.rb
@@ -1,0 +1,118 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "cgi"
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+PHOTO_URL = "/assets/images/Mohammad-Bayat-Avatar.jpg"
+
+PAGES = {
+  "/" => {
+    variant: "home",
+    link: "/about/biography"
+  },
+  "/about/biography" => {
+    variant: "biography"
+  },
+  "/about/resume" => {
+    variant: "resume"
+  }
+}.freeze
+
+
+def generated_page_path(site_dir, url)
+  return site_dir.join("index.html") if url == "/"
+
+  relative = url.delete_prefix("/").delete_suffix("/")
+  candidates = [
+    site_dir.join(relative, "index.html"),
+    site_dir.join("#{relative}.html"),
+    site_dir.join(relative)
+  ]
+
+  candidates.find(&:file?)
+end
+
+
+def attribute_value(tag, name)
+  match = tag.match(/\b#{Regexp.escape(name)}\s*=\s*(["'])(.*?)\1/mi)
+  return nil unless match
+
+  CGI.unescapeHTML(match[2])
+end
+
+
+def class_tokens(tag)
+  attribute_value(tag, "class").to_s.split
+end
+
+
+errors = []
+asset_path = SITE_DIR.join(PHOTO_URL.delete_prefix("/"))
+errors << "generated profile-photo asset is missing: #{asset_path}" unless asset_path.file?
+
+PAGES.each do |url, expectation|
+  page_path = generated_page_path(SITE_DIR, url)
+
+  unless page_path
+    errors << "generated page is missing: #{url}"
+    next
+  end
+
+  html = page_path.read(encoding: "UTF-8")
+  main_match = html.match(/<main\b[^>]*>(.*?)<\/main>/mi)
+
+  unless main_match
+    errors << "generated page does not contain <main>: #{url}"
+    next
+  end
+
+  main_html = main_match[1]
+  variant = expectation.fetch(:variant)
+  variant_class = "profile-photo-#{variant}"
+
+  if main_html.match?(/&lt;(?:a|img)\b.{0,1000}(?:profile-photo|Mohammad-Bayat-Avatar)/mi)
+    errors << "profile-photo HTML was escaped as visible text: #{url}"
+  end
+
+  photo_tags = main_html.scan(/<img\b[^>]*>/mi).select do |tag|
+    classes = class_tokens(tag)
+    classes.include?("profile-photo") && classes.include?(variant_class)
+  end
+
+  unless photo_tags.length == 1
+    errors << "expected exactly one #{variant_class} image, found #{photo_tags.length}: #{url}"
+    next
+  end
+
+  photo_tag = photo_tags.first
+  errors << "profile photo uses the wrong source: #{url}" unless attribute_value(photo_tag, "src") == PHOTO_URL
+  errors << "profile photo needs meaningful alt text: #{url}" if attribute_value(photo_tag, "alt").to_s.strip.empty?
+  errors << "profile photo width must remain 721: #{url}" unless attribute_value(photo_tag, "width") == "721"
+  errors << "profile photo height must remain 721: #{url}" unless attribute_value(photo_tag, "height") == "721"
+
+  next unless expectation[:link]
+
+  linked_photo = main_html.scan(/<a\b[^>]*>.*?<\/a>/mi).any? do |anchor|
+    opening_tag = anchor[/\A<a\b[^>]*>/mi]
+    classes = class_tokens(opening_tag.to_s)
+
+    classes.include?("profile-photo-link") &&
+      classes.include?("profile-photo-link-#{variant}") &&
+      attribute_value(opening_tag.to_s, "href") == expectation[:link] &&
+      anchor.include?(photo_tag)
+  end
+
+  errors << "homepage profile photo must link to Biography: #{url}" unless linked_photo
+end
+
+if errors.empty?
+  puts "Profile-photo validation passed: Home, Biography, and Resume render the shared portrait as HTML"
+  exit 0
+end
+
+warn "Profile-photo validation failed:"
+errors.each { |error| warn "- #{error}" }
+exit 1


### PR DESCRIPTION
## Summary

- fixes the Home and Biography portraits rendering as visible HTML text;
- keeps the existing `assets/images/Mohammad-Bayat-Avatar.jpg` file and does not generate or duplicate any image;
- adds the same portrait to Resume with a medium-sized circular treatment;
- adds a generated-site regression check for all three placements.

## Root cause

The shared include emitted the opening `<a>` and `<img>` tags across several lines. Because Home and Biography invoke that include from Markdown content, the custom GFM processor did not recognize those fragments as complete raw HTML tags and escaped them into visible text.

## Fix

- emit each link/image element as complete HTML on one line before Markdown parsing;
- insert the Resume portrait after Markdown conversion in the shared layout, so it cannot be escaped by the Markdown processor;
- retain the existing circular crop, restrained border, responsive centering, and desktop float;
- use a Resume size between the smaller Home image and the larger Biography image.

## Regression coverage

`scripts/validate_profile_photos.rb` checks the generated Home, Biography, and Resume pages and requires:

- one real `<img>` element with the expected variant class;
- the exact shared JPEG source;
- no escaped profile-photo HTML;
- the Home portrait link to Biography;
- the generated image asset to exist.

The check runs after the Jekyll build in the existing HTML and navigation validation job.