### PR TITLE
Reorder navigation around active work and improve the mobile sidebar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
         run: bundle exec jekyll build
       - name: Validate profile photos
         run: ruby scripts/validate_profile_photos.rb _site
+      - name: Validate navigation priorities
+        run: ruby scripts/validate_navigation_priorities.rb _site
       - name: Validate automatic child-page lists
         run: ruby scripts/validate_child_page_navigation.rb _site
       - name: Validate publication navigation

--- a/_config.yml
+++ b/_config.yml
@@ -100,16 +100,6 @@ aux_links_new_tab: true
 nav_enabled: true
 nav_sort: case_sensitive
 
-nav_external_links:
-  - title: OkBayat on GitHub
-    url: https://github.com/OkBayat
-
-  - title: OkBayat on LinkedIn
-    url: https://www.linkedin.com/in/okbayat/
-
-  - title: OkBayat on Instagram
-    url: https://www.instagram.com/OkBayat
-
 nav_error_report: true
 
 liquid:
@@ -119,7 +109,12 @@ liquid:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: "Copyright &copy; 2023&ndash;2026 Mohammad Bayat. Website source is available under the MIT license."
+footer_content: >-
+  Copyright &copy; 2023&ndash;2026 Mohammad Bayat.
+  Connect on <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>,
+  <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>, or
+  <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>.
+  Website source is available under the MIT license.
 
 last_edit_timestamp: true
 last_edit_time_format: "%b %e %Y at %I:%M %p"

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -1,3 +1,99 @@
+function closestNavExpander(target, siteNav) {
+  while (target && target !== siteNav) {
+    if (
+      target.classList &&
+      target.classList.contains("nav-list-expander")
+    ) {
+      return target
+    }
+
+    target = target.parentNode
+  }
+
+  return null
+}
+
+function collapseNavBranch(navItem) {
+  navItem.classList.remove("active")
+
+  var activeItems = navItem.querySelectorAll(".nav-list-item.active")
+  for (var i = 0; i < activeItems.length; i++) {
+    activeItems[i].classList.remove("active")
+  }
+
+  var expanders = navItem.querySelectorAll(".nav-list-expander")
+  for (var j = 0; j < expanders.length; j++) {
+    expanders[j].setAttribute("aria-pressed", "false")
+  }
+}
+
+function closeSiblingNavBranches(navItem) {
+  if (!navItem.parentNode) {
+    return
+  }
+
+  var siblings = navItem.parentNode.children
+  for (var i = 0; i < siblings.length; i++) {
+    var sibling = siblings[i]
+
+    if (
+      sibling !== navItem &&
+      sibling.classList &&
+      sibling.classList.contains("nav-list-item")
+    ) {
+      collapseNavBranch(sibling)
+    }
+  }
+}
+
+// Keep the mobile navigation compact: opening a branch closes its sibling
+// branches at the same level. Desktop navigation retains the theme's normal
+// multi-branch behavior.
+jtd.onReady(function () {
+  var siteNav = document.getElementById("site-nav")
+  var menuButton = document.getElementById("menu-button")
+  var backToTop = document.getElementById("back-to-top")
+
+  if (!siteNav || !menuButton) {
+    return
+  }
+
+  function mobileNavigationIsAvailable() {
+    return window.getComputedStyle(menuButton).display !== "none"
+  }
+
+  function syncBackToTopVisibility() {
+    if (!backToTop) {
+      return
+    }
+
+    backToTop.hidden =
+      mobileNavigationIsAvailable() &&
+      menuButton.classList.contains("nav-open")
+  }
+
+  jtd.addEvent(siteNav, "click", function (event) {
+    var expander = closestNavExpander(event.target, siteNav)
+
+    if (!expander || !mobileNavigationIsAvailable()) {
+      return
+    }
+
+    var navItem = expander.parentNode
+    var branchWillOpen = !navItem.classList.contains("active")
+
+    if (branchWillOpen) {
+      closeSiblingNavBranches(navItem)
+    }
+  })
+
+  // The theme's menu handler runs first and updates `nav-open`; this listener
+  // then mirrors that state onto the Back to top control.
+  jtd.addEvent(menuButton, "click", syncBackToTopVisibility)
+  jtd.addEvent(window, "resize", syncBackToTopVisibility)
+  syncBackToTopVisibility()
+})
+
 // When a language switch is the current URL, Just the Docs activates that
 // small switch link. Mirror the active state onto the article's primary
 // navigation link so the whole row is selected consistently.

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -1,9 +1,6 @@
 function closestNavExpander(target, siteNav) {
   while (target && target !== siteNav) {
-    if (
-      target.classList &&
-      target.classList.contains("nav-list-expander")
-    ) {
+    if (target.classList && target.classList.contains("nav-list-expander")) {
       return target
     }
 
@@ -68,8 +65,7 @@ jtd.onReady(function () {
     }
 
     backToTop.hidden =
-      mobileNavigationIsAvailable() &&
-      menuButton.classList.contains("nav-open")
+      mobileNavigationIsAvailable() && menuButton.classList.contains("nav-open")
   }
 
   jtd.addEvent(siteNav, "click", function (event) {

--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -4,7 +4,7 @@ title: Contact
 parent: About
 nav_order: 4
 direction: ltr
-description: "Public contact and scheduling information for Mohammad Bayat."
+description: "Public contact, profile, and scheduling information for Mohammad Bayat."
 permalink: /about/contact
 ---
 
@@ -18,6 +18,12 @@ A useful message should include:
 - the subject or project you are writing about;
 - why you think a conversation or collaboration would be useful;
 - the decision, question, or next step you have in mind.
+
+## Elsewhere
+
+- [GitHub](https://github.com/OkBayat) — source code and public repositories
+- [LinkedIn](https://www.linkedin.com/in/okbayat/) — professional profile
+- [Instagram](https://www.instagram.com/OkBayat) — public updates
 
 ## Scheduling
 

--- a/docs/about/current-interests/current-interests.md
+++ b/docs/about/current-interests/current-interests.md
@@ -2,7 +2,7 @@
 layout: default
 title: Current Work
 parent: About
-nav_order: 3
+nav_order: 1.5
 direction: ltr
 description: "The two active bodies of Mohammad Bayat's work: quantitative systems and organizations, and human learning and transformation."
 last_modified_date: 2026-07-17

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -12,8 +12,8 @@ permalink: /about
 This section provides context for the work published on okbayat.com.
 
 - [Biography](/about/biography) — a short professional and intellectual background
-- [Resume](/about/resume) — selected experience, projects, and practice
 - [Current Work](/about/current-interests) — the two active bodies of work and current priorities
+- [Resume](/about/resume) — selected experience, projects, and practice
 - [Contact](/about/contact) — public contact and scheduling information
 
 For the two main bodies of work, see [K2Quant](/building/k2quant) and [Human Transformation](/human-transformation). For written work, see [Thinking](/thinking).

--- a/docs/building/experiments/experiments.md
+++ b/docs/building/experiments/experiments.md
@@ -3,6 +3,7 @@ layout: default
 title: Experiments
 parent: Building
 nav_order: 5
+nav_exclude: true
 direction: ltr
 description: "Documented product and research experiments, including methods, results, and limitations."
 permalink: /building/experiments

--- a/docs/building/index.md
+++ b/docs/building/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Building
-nav_order: 4
+nav_order: 3
 direction: ltr
 description: "Companies, software projects, systems, social-impact initiatives, and documented experiments by Mohammad Bayat."
 permalink: /building
@@ -12,12 +12,6 @@ permalink: /building
 This section documents work that exists in practice: companies, software, systems, bounded initiatives, and experiments.
 
 It is organized by what is being built rather than by every question that the work raises. Cross-cutting questions about learning, language, identity, context, performance, leadership, and coordination are indexed separately under [Human Transformation](/human-transformation).
-
-## Publications & Notes
-
-[Building Publications & Notes](/building/publications) is the topical index for essays, research notes, reading notes, translations, project reflections, and experiment reports about software, AI, agent systems, entrepreneurship, company-building, operations, and decision-making.
-
-The writing remains in its canonical content-type section. This index creates a coherent Building lens without creating separate copies or parallel technical and startup blogs.
 
 ## Main Bodies of Work
 
@@ -30,6 +24,12 @@ My main company-building work around quantitative systems, software development,
 An independent research-and-building project about learning, memory, language practice, and learning technology. Its first working artifact is a vocabulary-practice application.
 
 Vocora is a concrete software project and also one bounded setting inside the broader Human Transformation inquiry. It does not represent every question in that program.
+
+## Publications & Notes
+
+[Building Publications & Notes](/building/publications) is the topical index for essays, research notes, reading notes, translations, project reflections, and experiment reports about software, AI, agent systems, entrepreneurship, company-building, operations, and decision-making.
+
+The writing remains in its canonical content-type section. This index creates a coherent Building lens without creating separate copies or parallel technical and startup blogs.
 
 ## Other Work
 

--- a/docs/building/k2quant/index.md
+++ b/docs/building/k2quant/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: K2Quant
 parent: Building
-nav_order: 2
+nav_order: 1
 direction: ltr
 description: "Mohammad Bayat's company-building work in quantitative systems, software, artificial intelligence, and technical operations."
 permalink: /building/k2quant

--- a/docs/building/publications.md
+++ b/docs/building/publications.md
@@ -2,7 +2,7 @@
 layout: default
 title: Publications & Notes
 parent: Building
-nav_order: 1
+nav_order: 3
 direction: ltr
 description: "A curated index of essays, research notes, reading notes, translations, and project records about software, AI, entrepreneurship, organizations, and systems."
 permalink: /building/publications

--- a/docs/building/vocora/index.md
+++ b/docs/building/vocora/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Vocora
 parent: Building
-nav_order: 3
+nav_order: 2
 direction: ltr
 description: "An open-source research-and-building project about learning, memory, language practice, and learning technology."
 permalink: /building/vocora

--- a/docs/human-transformation/field-projects/index.md
+++ b/docs/human-transformation/field-projects/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Field Projects
 parent: Human Transformation
-nav_order: 2
+nav_order: 3
 direction: ltr
 description: "Practice-based projects used to document questions about learning, coordination, context, and durable change."
 permalink: /human-transformation/field-projects

--- a/docs/human-transformation/index.md
+++ b/docs/human-transformation/index.md
@@ -1,10 +1,10 @@
 ---
 layout: default
 title: Human Transformation
-nav_order: 3
+nav_order: 4
 direction: ltr
 description: "An independent inquiry into learning, language, identity, context, performance, leadership, and durable human change."
-last_modified_date: 2026-07-17
+last_modified_date: 2026-07-19
 permalink: /human-transformation
 ---
 
@@ -25,11 +25,11 @@ A field observation, participant account, conceptual model, and controlled resul
 ## How the Work Is Organized
 
 - **Research Agenda** records the active questions and their status.
+- **Publications & Notes** is a curated index of canonical writing across the site.
 - **Field Projects** document settings in which learning and coordination are observed over time.
 - **Practice & Programs** preserve the history, questions, and limitations of facilitated programs.
 - **Leadership** contains the existing leadership, coaching, course, research, and source archive.
 - **Source Library** maps concepts and source lineages without presenting them as my conclusions.
-- **Publications & Notes** is a curated index of canonical writing across the site.
 - **Research Log** records changes in questions, methods, interpretations, and evidence standards.
 
 ## Working Standard

--- a/docs/human-transformation/practice-programs/index.md
+++ b/docs/human-transformation/practice-programs/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Practice & Programs
 parent: Human Transformation
-nav_order: 3
+nav_order: 4
 direction: ltr
 description: "Durable records of facilitated programs, their source lineage, questions, observations, revisions, and limits."
 permalink: /human-transformation/practice-programs

--- a/docs/human-transformation/publications.md
+++ b/docs/human-transformation/publications.md
@@ -2,7 +2,7 @@
 layout: default
 title: Publications & Notes
 parent: Human Transformation
-nav_order: 6
+nav_order: 2
 direction: ltr
 description: "A curated index of canonical essays, research notes, reading notes, translations, field records, and project pages related to human transformation."
 permalink: /human-transformation/publications

--- a/docs/human-transformation/source-library.md
+++ b/docs/human-transformation/source-library.md
@@ -2,7 +2,7 @@
 layout: default
 title: Source Library
 parent: Human Transformation
-nav_order: 5
+nav_order: 6
 direction: ltr
 description: "A map of source material, translations, concept notes, and intellectual lineages related to human transformation."
 permalink: /human-transformation/source-library

--- a/docs/leadership/index.md
+++ b/docs/leadership/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Leadership
 parent: Human Transformation
-nav_order: 4
+nav_order: 5
 direction: ltr
 description: "Leadership, coaching, programs, source material, and practice-based inquiry within the broader Human Transformation work."
 permalink: /leadership

--- a/docs/voice/podcast/index.md
+++ b/docs/voice/podcast/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Inja-Anja
 parent: Podcast
 nav_order: 1
+nav_exclude: true
 direction: rtl
 lang: fa
 locale: fa_IR

--- a/scripts/validate_navigation_priorities.rb
+++ b/scripts/validate_navigation_priorities.rb
@@ -115,6 +115,18 @@ unless experiments_path
   exit 1
 end
 
+if normalized_hrefs.include?("/voice/podcast")
+  warn "The single Inja-Anja series must not create a redundant Podcast submenu"
+  exit 1
+end
+
+podcast_path = generated_page_path(SITE_DIR, "/voice/podcast")
+
+unless podcast_path
+  warn "The Inja-Anja page must remain published and reachable from Podcast"
+  exit 1
+end
+
 social_urls = %w[
   https://github.com/OkBayat
   https://www.linkedin.com/in/okbayat/

--- a/scripts/validate_navigation_priorities.rb
+++ b/scripts/validate_navigation_priorities.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "pathname"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+
+
+def generated_page_path(site_dir, url)
+  normalized = url.to_s.sub(%r{\A/}, "").sub(%r{/\z}, "")
+  candidates = [
+    site_dir.join("#{normalized}.html"),
+    site_dir.join(normalized, "index.html")
+  ]
+
+  candidates.find(&:file?)
+end
+
+
+def normalize_internal_url(url)
+  normalized = url.to_s.split(/[?#]/, 2).first
+  normalized = normalized.sub(%r{/index\.html\z}, "")
+  normalized = normalized.sub(/\.html\z/, "")
+  normalized = normalized.sub(%r{/\z}, "") unless normalized == "/"
+  normalized.empty? ? "/" : normalized
+end
+
+
+def navigation_hrefs(html)
+  nav_match = html.match(/<nav\b[^>]*id=["']site-nav["'][^>]*>(.*?)<\/nav>/mi)
+
+  unless nav_match
+    warn "Generated page does not contain #site-nav"
+    exit 1
+  end
+
+  nav_match[1].scan(/href=["']([^"']+)["']/i).flatten
+end
+
+
+def assert_order(normalized_hrefs, label, expected_urls)
+  positions = expected_urls.map do |url|
+    normalized = normalize_internal_url(url)
+    index = normalized_hrefs.index(normalized)
+
+    unless index
+      warn "#{label}: missing navigation link #{url}"
+      exit 1
+    end
+
+    index
+  end
+
+  return if positions.each_cons(2).all? { |left, right| left < right }
+
+  warn "#{label}: navigation order is incorrect"
+  expected_urls.zip(positions).each { |url, index| warn "- #{url}: #{index}" }
+  exit 1
+end
+
+
+home_path = generated_page_path(SITE_DIR, "/")
+
+unless home_path
+  warn "Generated Home page is missing"
+  exit 1
+end
+
+home_html = home_path.read(encoding: "UTF-8")
+raw_hrefs = navigation_hrefs(home_html)
+normalized_hrefs = raw_hrefs.map { |href| normalize_internal_url(href) }
+
+assert_order(
+  normalized_hrefs,
+  "Primary navigation",
+  %w[/ /thinking /building /human-transformation /voice /about]
+)
+
+assert_order(
+  normalized_hrefs,
+  "Building navigation",
+  %w[/building/k2quant /building/vocora /building/publications /building/projects]
+)
+
+assert_order(
+  normalized_hrefs,
+  "Human Transformation navigation",
+  %w[
+    /human-transformation/research-agenda
+    /human-transformation/publications
+    /human-transformation/field-projects
+    /human-transformation/practice-programs
+    /leadership
+    /human-transformation/source-library
+    /human-transformation/research-log
+  ]
+)
+
+assert_order(
+  normalized_hrefs,
+  "About navigation",
+  %w[/about/biography /about/current-interests /about/resume /about/contact]
+)
+
+if normalized_hrefs.include?("/building/experiments")
+  warn "Experiments must remain outside the global sidebar until a formal report exists"
+  exit 1
+end
+
+experiments_path = generated_page_path(SITE_DIR, "/building/experiments")
+
+unless experiments_path
+  warn "Experiments must remain published and reachable from section pages"
+  exit 1
+end
+
+social_urls = %w[
+  https://github.com/OkBayat
+  https://www.linkedin.com/in/okbayat/
+  https://www.instagram.com/OkBayat
+]
+
+social_urls.each do |url|
+  if raw_hrefs.include?(url)
+    warn "External profile must not appear in the global sidebar: #{url}"
+    exit 1
+  end
+end
+
+contact_path = generated_page_path(SITE_DIR, "/about/contact")
+
+unless contact_path
+  warn "Generated Contact page is missing"
+  exit 1
+end
+
+contact_html = contact_path.read(encoding: "UTF-8")
+
+social_urls.each do |url|
+  unless contact_html.include?(%(href="#{url}"))
+    warn "Contact page is missing external profile: #{url}"
+    exit 1
+  end
+
+  unless home_html.include?(%(href="#{url}"))
+    warn "Footer is missing external profile: #{url}"
+    exit 1
+  end
+end
+
+javascript_path = SITE_DIR.join("assets/js/just-the-docs.js")
+
+unless javascript_path.file?
+  warn "Generated Just the Docs JavaScript asset is missing"
+  exit 1
+end
+
+javascript = javascript_path.read(encoding: "UTF-8")
+%w[closeSiblingNavBranches syncBackToTopVisibility].each do |marker|
+  unless javascript.include?(marker)
+    warn "Generated JavaScript is missing mobile-navigation behavior: #{marker}"
+    exit 1
+  end
+end
+
+puts "Navigation priority validation passed"


### PR DESCRIPTION
## Summary

This PR applies the navigation priorities derived from the current site content and personal-brand structure.

### Primary navigation

- keeps `Home` and `Thinking` first;
- moves `Building` ahead of `Human Transformation`;
- keeps `Podcast` and `About` after the two active bodies of work.

### Building

- orders the section as `K2Quant`, `Vocora`, `Publications & Notes`, and `Projects`;
- keeps the Experiments page accessible from the Building hub and topical index;
- hides the Experiments hub from the global sidebar until a formal report exists;
- aligns the Building landing page with the same priority order.

### Human Transformation

- keeps `Research Agenda` first;
- moves `Publications & Notes` to the second position;
- follows with `Field Projects`, `Practice & Programs`, `Leadership`, `Source Library`, and `Research Log`;
- aligns the landing-page explanation with the sidebar order.

### Podcast

- removes the redundant one-item `Podcast → Inja-Anja` submenu;
- keeps the Persian Inja-Anja page and its existing `/voice/podcast` URL published and linked from the Podcast page.

### About and external profiles

- moves `Current Work` ahead of `Resume`;
- removes GitHub, LinkedIn, and Instagram from the global sidebar;
- places those profiles on Contact and in the footer instead.

### Mobile navigation

- makes sibling branches behave as an accordion on mobile, while preserving normal desktop behavior;
- hides the fixed `Back to top` control while the mobile navigation is open;
- preserves the existing active-language navigation behavior.

## Regression coverage

`scripts/validate_navigation_priorities.rb` validates the generated site and requires:

- the intended primary and section-level order;
- Experiments to remain published but outside the global sidebar;
- the Inja-Anja page to remain published without creating a redundant Podcast submenu;
- social profiles to remain outside the sidebar and available on Contact and in the footer;
- the mobile accordion and Back-to-top behavior to be present in the generated JavaScript.

## Validation

CI run 1665 passed, including:

- Jekyll 3.9 and 4.3 builds across the supported Ruby and operating-system matrix;
- the GitHub Pages build;
- HTML and navigation validation;
- the new navigation-priority regression check;
- CSS and JavaScript formatting/lint checks;
- publication registry, publication navigation, language-switch, and profile-photo checks.
