### PR TITLE
Add compact social icon buttons to the sidebar footer

### DIFF
--- a/_includes/nav_footer_custom.html
+++ b/_includes/nav_footer_custom.html
@@ -1,0 +1,55 @@
+<footer class="site-footer sidebar-social-footer">
+  <nav class="sidebar-social-links" aria-label="Social profiles and email">
+    <a
+      class="sidebar-social-link"
+      href="https://www.linkedin.com/in/okbayat/"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="LinkedIn"
+      data-label="LinkedIn"
+    >
+      <svg class="sidebar-social-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708C16 15.487 15.474 16 14.825 16H1.175C.526 16 0 15.487 0 14.854V1.146Zm4.943 12.248V6.169H2.542v7.225h2.401ZM3.743 5.182c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.343-1.248S2.4 3.225 2.4 3.934c0 .694.521 1.248 1.327 1.248h.016Zm2.869 8.212h2.4V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.4V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.19h.016v-1.02h-2.4c.03.663 0 7.226 0 7.226Z" />
+      </svg>
+    </a>
+
+    <a
+      class="sidebar-social-link"
+      href="https://www.instagram.com/OkBayat"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Instagram"
+      data-label="Instagram"
+    >
+      <svg class="sidebar-social-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <rect x="3" y="3" width="18" height="18" rx="5" fill="none" stroke="currentColor" stroke-width="2" />
+        <circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2" />
+        <circle cx="17.5" cy="6.5" r="1.25" fill="currentColor" />
+      </svg>
+    </a>
+
+    <a
+      class="sidebar-social-link"
+      href="https://github.com/OkBayat"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="GitHub"
+      data-label="GitHub"
+    >
+      <svg class="sidebar-social-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M8 0C3.58 0 0 3.64 0 8.13c0 3.59 2.29 6.64 5.47 7.71.4.08.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.38-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.53-.01-.54.63-.01 1.08.58 1.23.82.72 1.22 1.87.88 2.33.67.07-.53.28-.88.51-1.08-1.78-.2-3.64-.9-3.64-4.01 0-.89.31-1.62.82-2.19-.08-.2-.36-1.03.08-2.16 0 0 .67-.22 2.2.84a7.5 7.5 0 0 1 4 0c1.53-1.06 2.2-.84 2.2-.84.44 1.13.16 1.96.08 2.16.51.57.82 1.3.82 2.19 0 3.12-1.87 3.81-3.65 4.01.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.12 8.12 0 0 0 16 8.13C16 3.64 12.42 0 8 0Z" />
+      </svg>
+    </a>
+
+    <a
+      class="sidebar-social-link"
+      href="mailto:me@OkBayat.com"
+      aria-label="Email"
+      data-label="Email"
+    >
+      <svg class="sidebar-social-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M3 5h18v14H3V5Zm2 2v.51l7 4.67 7-4.67V7H5Zm14 10V9.91l-7 4.67-7-4.67V17h14Z" />
+      </svg>
+    </a>
+  </nav>
+</footer>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -126,6 +126,96 @@
   }
 }
 
+.sidebar-social-footer {
+  overflow: visible;
+  padding-top: $sp-3;
+  padding-bottom: $sp-4;
+  border-top: $border $border-color;
+}
+
+.sidebar-social-links {
+  display: flex;
+  gap: $sp-2;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  overflow: visible;
+}
+
+.sidebar-social-link {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  color: $link-color;
+  text-decoration: none;
+  background-color: $sidebar-color;
+  border: $border $border-color;
+  border-radius: 6px;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
+
+  &::after {
+    position: absolute;
+    bottom: calc(100% + 0.5rem);
+    left: 50%;
+    z-index: 2;
+    padding: 0.375rem 0.5rem;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1;
+    color: $body-background-color;
+    white-space: nowrap;
+    pointer-events: none;
+    content: attr(data-label);
+    background-color: $body-heading-color;
+    border-radius: 3px;
+    opacity: 0;
+    transform: translate(-50%, 0.25rem);
+    transition:
+      opacity 0.15s ease,
+      transform 0.15s ease;
+  }
+
+  &:hover,
+  &:focus-visible {
+    color: $link-color;
+    text-decoration: none;
+    background-color: $feedback-color;
+    border-color: $link-color;
+    transform: translateY(-1px);
+  }
+
+  &:hover::after,
+  &:focus-visible::after {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $link-color;
+    outline-offset: 2px;
+  }
+}
+
+.sidebar-social-icon {
+  flex: 0 0 auto;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-social-link,
+  .sidebar-social-link::after {
+    transition: none;
+  }
+}
+
 .article-language-switch {
   direction: ltr;
   font-size: 1rem;

--- a/scripts/validate_navigation_priorities.rb
+++ b/scripts/validate_navigation_priorities.rb
@@ -39,6 +39,19 @@ def navigation_hrefs(html)
 end
 
 
+def footer_html(html, required_class, label)
+  pattern = /<footer\b[^>]*class=["'][^"']*\b#{Regexp.escape(required_class)}\b[^"']*["'][^>]*>(.*?)<\/footer>/mi
+  match = html.match(pattern)
+
+  unless match
+    warn "Generated page does not contain #{label}"
+    exit 1
+  end
+
+  match[1]
+end
+
+
 def assert_order(normalized_hrefs, label, expected_urls)
   positions = expected_urls.map do |url|
     normalized = normalize_internal_url(url)
@@ -135,7 +148,61 @@ social_urls = %w[
 
 social_urls.each do |url|
   if raw_hrefs.include?(url)
-    warn "External profile must not appear in the global sidebar: #{url}"
+    warn "External profile must not appear as a full navigation row: #{url}"
+    exit 1
+  end
+end
+
+sidebar_actions = [
+  ["LinkedIn", "https://www.linkedin.com/in/okbayat/"],
+  ["Instagram", "https://www.instagram.com/OkBayat"],
+  ["GitHub", "https://github.com/OkBayat"],
+  ["Email", "mailto:me@OkBayat.com"]
+]
+
+sidebar_footer = footer_html(home_html, "sidebar-social-footer", "the sidebar social footer")
+sidebar_hrefs = sidebar_footer.scan(/href=["']([^"']+)["']/i).flatten
+expected_sidebar_hrefs = sidebar_actions.map(&:last)
+
+unless sidebar_hrefs == expected_sidebar_hrefs
+  warn "Sidebar social buttons are missing, reordered, or contain an unexpected link"
+  warn "Expected: #{expected_sidebar_hrefs.join(' | ')}"
+  warn "Actual:   #{sidebar_hrefs.join(' | ')}"
+  exit 1
+end
+
+sidebar_link_count = sidebar_footer.scan(/class=["'][^"']*\bsidebar-social-link\b[^"']*["']/i).length
+sidebar_icon_count = sidebar_footer.scan(/class=["'][^"']*\bsidebar-social-icon\b[^"']*["']/i).length
+
+unless sidebar_link_count == 4 && sidebar_icon_count == 4
+  warn "Sidebar social footer must contain exactly four icon buttons"
+  warn "Links: #{sidebar_link_count}; icons: #{sidebar_icon_count}"
+  exit 1
+end
+
+sidebar_actions.each do |label, url|
+  unless sidebar_footer.include?(%(href="#{url}"))
+    warn "Sidebar social footer is missing #{label}: #{url}"
+    exit 1
+  end
+
+  unless sidebar_footer.include?(%(aria-label="#{label}")) && sidebar_footer.include?(%(data-label="#{label}"))
+    warn "Sidebar social button is missing its accessible or hover label: #{label}"
+    exit 1
+  end
+end
+
+custom_scss_path = ROOT.join("_sass/custom/custom.scss")
+custom_scss = custom_scss_path.read(encoding: "UTF-8")
+
+[
+  ".sidebar-social-link",
+  "content: attr(data-label);",
+  "&:hover::after",
+  "&:focus-visible::after"
+].each do |marker|
+  unless custom_scss.include?(marker)
+    warn "Sidebar social button styling is missing hover-label behavior: #{marker}"
     exit 1
   end
 end
@@ -148,6 +215,7 @@ unless contact_path
 end
 
 contact_html = contact_path.read(encoding: "UTF-8")
+main_footer = footer_html(home_html, "text-left", "the main page footer")
 
 social_urls.each do |url|
   unless contact_html.include?(%(href="#{url}"))
@@ -155,10 +223,15 @@ social_urls.each do |url|
     exit 1
   end
 
-  unless home_html.include?(%(href="#{url}"))
-    warn "Footer is missing external profile: #{url}"
+  unless main_footer.include?(%(href="#{url}"))
+    warn "Main page footer is missing external profile: #{url}"
     exit 1
   end
+end
+
+unless contact_html.include?('href="mailto:me@OkBayat.com"')
+  warn "Contact page is missing the public email address"
+  exit 1
 end
 
 javascript_path = SITE_DIR.join("assets/js/just-the-docs.js")
@@ -176,4 +249,4 @@ javascript = javascript_path.read(encoding: "UTF-8")
   end
 end
 
-puts "Navigation priority validation passed"
+puts "Navigation priority and sidebar social-button validation passed"


### PR DESCRIPTION
## Summary

This PR restores the social profiles to the bottom of the sidebar without bringing back the former full-width navigation rows.

### Sidebar footer

- adds four compact icon buttons in this order: `LinkedIn`, `Instagram`, `GitHub`, and `Email`;
- keeps the buttons together in one horizontal row at the bottom of the sidebar;
- shows the service name above the button on hover and keyboard focus;
- uses inline SVG icons, so no icon font or external asset request is required;
- gives every link an accessible label;
- opens external profiles in a new tab with `noopener noreferrer` and uses the existing public `mailto:` address for Email.

### Existing discovery paths

The links already added to the Contact page and the main page footer remain unchanged. The new row is an additional compact sidebar utility, not a replacement for those locations and not part of the primary navigation hierarchy.

### Regression coverage

The existing navigation-priority validator now also requires:

- exactly four sidebar icon buttons;
- the intended order and URLs;
- matching accessible and hover labels;
- icon markup for every button;
- hover/focus tooltip styling;
- the social profiles to remain absent as full navigation rows;
- the Contact and main-footer profile links to remain present.

## Validation

CI run 1667 passed, including:

- Jekyll 3.9 and 4.3 builds across the supported Ruby and operating-system matrix;
- the GitHub Pages build;
- HTML and navigation validation;
- CSS and JavaScript formatting/lint checks;
- publication, language-switch, profile-photo, and navigation-priority regression checks.
