### PR TITLE
Refine profile photo sizing and spacing on mobile

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -236,8 +236,8 @@
 }
 
 .profile-photo-link-home {
-  width: 8rem;
-  margin: 0 auto $sp-5;
+  width: 7.5rem;
+  margin: $sp-4 auto $sp-5;
 }
 
 .profile-photo {
@@ -251,13 +251,13 @@
 }
 
 .profile-photo-biography {
-  width: 12rem;
-  margin: 0 auto $sp-5;
+  width: 10.5rem;
+  margin: $sp-4 auto $sp-5;
 }
 
 .profile-photo-resume {
-  width: 10rem;
-  margin: 0 auto $sp-5;
+  width: 9.5rem;
+  margin: $sp-4 auto $sp-5;
 }
 
 @include mq(md) {


### PR DESCRIPTION
## Summary

- keeps the existing mobile content order: heading first, portrait second, introduction third;
- reduces the portrait sizes so the images support the page hierarchy without dominating it;
- adds explicit mobile spacing between the heading or role line, the portrait, and the introduction;
- leaves the existing desktop float, sizes, image source, circular crop, and page content unchanged.

## Mobile treatment

- Home: `7.5rem` / 120px
- Biography: `10.5rem` / 168px
- Resume: `9.5rem` / 152px
- Top spacing: `$sp-4` / 16px
- Bottom spacing: `$sp-5` / 24px

The portrait remains after the `h1` on all three pages. This preserves the semantic page hierarchy and keeps the mobile pages from reading like social-profile cards.

## Scope

Only `_sass/custom/custom.scss` is changed.