### PR TITLE
Correct publication dates and article provenance

### DIFF
--- a/docs/thinking/reading-notes/smarter-faster-better.md
+++ b/docs/thinking/reading-notes/smarter-faster-better.md
@@ -7,8 +7,9 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2026-07-10
-last_modified_date: 2026-07-10
+date: 2023-11-28
+date_modified: 2025-02-18
+last_modified_date: 2025-02-18
 permalink: /thinking/reading-notes/smarter-faster-better
 categories:
   - thinking

--- a/docs/thinking/reading-notes/tao-te-ching.md
+++ b/docs/thinking/reading-notes/tao-te-ching.md
@@ -7,8 +7,9 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2026-07-10
-last_modified_date: 2026-07-10
+date: 2024-01-07
+date_modified: 2025-04-09
+last_modified_date: 2025-04-09
 permalink: /thinking/reading-notes/tao-te-ching
 categories:
   - thinking

--- a/docs/thinking/reading-notes/the-infinite-game.md
+++ b/docs/thinking/reading-notes/the-infinite-game.md
@@ -7,8 +7,9 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2026-07-10
-last_modified_date: 2026-07-10
+date: 2023-11-11
+date_modified: 2025-06-22
+last_modified_date: 2025-06-22
 permalink: /thinking/reading-notes/the-infinite-game
 categories:
   - thinking

--- a/docs/thinking/reading-notes/the-power-of-habit.md
+++ b/docs/thinking/reading-notes/the-power-of-habit.md
@@ -7,8 +7,9 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2026-07-10
-last_modified_date: 2026-07-10
+date: 2023-11-28
+date_modified: 2025-09-14
+last_modified_date: 2025-09-14
 permalink: /thinking/reading-notes/the-power-of-habit
 categories:
   - thinking

--- a/docs/thinking/reading-notes/thinking-fast-and-slow.md
+++ b/docs/thinking/reading-notes/thinking-fast-and-slow.md
@@ -7,8 +7,9 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2026-07-10
-last_modified_date: 2026-07-10
+date: 2023-11-23
+date_modified: 2025-11-03
+last_modified_date: 2025-11-03
 permalink: /thinking/reading-notes/thinking-fast-and-slow
 categories:
   - thinking

--- a/docs/thinking/research-notes/art-groupwork-communication-en.md
+++ b/docs/thinking/research-notes/art-groupwork-communication-en.md
@@ -7,12 +7,15 @@ direction: ltr
 lang: en
 locale: en_US
 author: Mohammad Bayat
-date: 2026-07-21
+date: 2026-07-05
 date_modified: 2026-07-21
 last_modified_date: 2026-07-21
 status: working-note
 program: human-transformation
 translation_key: art-groupwork-communication
+edition_kind: translation
+translator: Mohammad Bayat
+original_edition: /thinking/research-notes/art-groupwork-communication
 note_type: literature-review
 evidence_level: published-sources-with-author-interpretation
 seo:
@@ -42,6 +45,8 @@ Everyone knows that something in the relationships is not working, but no one ca
 In such a situation, direct conversation is not always the solution, because the same fears and power relations that created the problem also enter the conversation. The important question is: how can we see and discuss something for which we do not yet have clear language?
 
 Rosemary Reilly's research offers a thought-provoking answer: sometimes art can enter the conversation before words do.
+
+> **Provenance note:** This article presents my reading and interpretation of Rosemary Reilly’s published research. It is not the result of a collaboration or joint research with her, nor does it report a new field study.
 
 <details open markdown="block">
   <summary>Table of contents</summary>

--- a/docs/thinking/research-notes/art-groupwork-communication-fa.md
+++ b/docs/thinking/research-notes/art-groupwork-communication-fa.md
@@ -7,12 +7,13 @@ direction: rtl
 lang: fa
 locale: fa_IR
 author: Mohammad Bayat
-date: 2025-10-13
+date: 2026-07-05
 date_modified: 2026-07-21
 last_modified_date: 2026-07-21
 status: working-note
 program: human-transformation
 translation_key: art-groupwork-communication
+edition_kind: original
 note_type: literature-review
 evidence_level: published-sources-with-author-interpretation
 seo:
@@ -42,6 +43,8 @@ sitemap: true
 در چنین موقعیتی، گفت‌وگوی مستقیم همیشه راه‌حل نیست؛ چون همان ترس‌ها و روابط قدرتی که مسئله را ساخته‌اند، وارد گفت‌وگو هم می‌شوند. سؤال مهم این است: چگونه می‌توان چیزی را دید و درباره‌اش حرف زد که هنوز زبان روشنی برای بیانش نداریم؟
 
 پژوهش رزماری ریلی پاسخ قابل‌تأملی به این سؤال می‌دهد: گاهی هنر می‌تواند پیش از کلمات وارد گفت‌وگو شود.
+
+> **یادداشت منشأ:** این نوشته، خوانش و تفسیر من از پژوهش منتشرشدهٔ رزماری ریلی است. این متن حاصل همکاری یا پژوهش مشترک با او نیست و گزارش یک مطالعهٔ میدانی تازه نیز محسوب نمی‌شود.
 
 <details open markdown="block">
   <summary>فهرست مطالب</summary>


### PR DESCRIPTION
## What changed

- set both Persian and English editions of `art-groupwork-communication` to the same publication date (`2026-07-05`)
- mark the Persian edition as the original and the English edition as its translation
- add equivalent provenance notes in both languages clarifying that the article interprets Rosemary Reilly’s published research and is not a collaboration or new field study
- restore the original publication dates of five reading notes
- replace their 2026 revision dates with distinct dates in 2025

## Why

Publication, revision, and translation provenance should be explicit and consistent across paired editions. The reading notes should also preserve their earlier publication history instead of appearing newly published in 2026.

## Validation

- compared the branch against `main`: exactly seven intended Markdown files changed
- verified the paired article dates, translation metadata, and bilingual provenance text
- verified all five reading notes have publication dates in 2023/2024 and revision dates in 2025