### PR TITLE
Archive legacy leadership research

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,11 +25,15 @@ defaults:
     values:
       nav_exclude: true
 
+  # Historical material remains reachable from the footer archive, but it does
+  # not compete with current work in navigation, search, or the sitemap.
   - scope:
-      path: "docs/leadership/research"
+      path: "docs/archive"
       type: "pages"
     values:
       nav_exclude: true
+      search_exclude: true
+      sitemap: false
 
   - scope:
       path: "docs/leadership/resources"
@@ -114,6 +118,7 @@ footer_content: >-
   Connect on <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>,
   <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>, or
   <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>.
+  Browse the <a href="/archive/">Archive</a>.
   Website source is available under the MIT license.
 
 last_edit_timestamp: true

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Archive
+direction: ltr
+permalink: /archive/
+---
+
+# Archive
+
+This archive preserves historical material that is no longer part of the site's current research, publication, or program pathways.
+
+- [Leadership Research Archive](/archive/leadership-research/) — earlier Persian-language working pages about leadership programs, participation, coordination, and integrity.

--- a/docs/archive/leadership-research/commitment-context.md
+++ b/docs/archive/leadership-research/commitment-context.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: بافتمان تعهد
-parent: Research Agenda
+parent: Leadership Research Archive
 direction: rtl
-permalink: /human-transformation/research-agenda/commitment-context
+permalink: /archive/leadership-research/commitment-context
 ---
 
 # نگاه اولیه به پویایی‌های مشارکت در دوره‌های رایگان و پولی

--- a/docs/archive/leadership-research/course-experiments.md
+++ b/docs/archive/leadership-research/course-experiments.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: تجربه‌گری‌های دوره
-parent: Research Agenda
+parent: Leadership Research Archive
 direction: rtl
-permalink: /human-transformation/research-agenda/course-experiments
+permalink: /archive/leadership-research/course-experiments
 ---
 
 # تجربه‌گری‌های دوره

--- a/docs/archive/leadership-research/created-future.md
+++ b/docs/archive/leadership-research/created-future.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: پروژه‌ی مشترک
-parent: Research Agenda
+parent: Leadership Research Archive
 direction: rtl
-permalink: /human-transformation/research-agenda/created-future
+permalink: /archive/leadership-research/created-future
 ---
 
 # پروژه‌ی مشترک

--- a/docs/archive/leadership-research/index.md
+++ b/docs/archive/leadership-research/index.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Leadership Research Archive
+parent: Archive
+direction: ltr
+permalink: /archive/leadership-research/
+---
+
+# Leadership Research Archive
+
+These Persian-language pages preserve earlier working observations and developing hypotheses from leadership programs. They are historical records, not current research claims, and are not part of the Human Transformation Research Agenda.
+
+- [بافتمان تعهد](/archive/leadership-research/commitment-context)
+- [بافتمان دعوت](/archive/leadership-research/invitation-context)
+- [تجربه‌گری‌های دوره](/archive/leadership-research/course-experiments)
+- [شاخص یکپارچگی](/archive/leadership-research/integrity-index)
+- [پروژه‌ی مشترک](/archive/leadership-research/created-future)

--- a/docs/archive/leadership-research/integrity-index.md
+++ b/docs/archive/leadership-research/integrity-index.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: شاخص یکپارچگی
-parent: Research Agenda
+parent: Leadership Research Archive
 direction: rtl
-permalink: /human-transformation/research-agenda/integrity-index
+permalink: /archive/leadership-research/integrity-index
 ---
 
 # شاخص یکپارچگی

--- a/docs/archive/leadership-research/invitation-context.md
+++ b/docs/archive/leadership-research/invitation-context.md
@@ -1,9 +1,9 @@
 ---
 layout: default
 title: بافتمان دعوت
-parent: Research Agenda
+parent: Leadership Research Archive
 direction: rtl
-permalink: /human-transformation/research-agenda/invitation-context
+permalink: /archive/leadership-research/invitation-context
 ---
 
 # تاثیر دعوت بر خلق بافتمان‌های جدید و اثر اتخاذ ایستمان منشاء بودن در دعوت از دیگران

--- a/docs/human-transformation/research-agenda-en.md
+++ b/docs/human-transformation/research-agenda-en.md
@@ -100,8 +100,6 @@ The first public field record is [Learning Circle](/human-transformation/field-p
 - How do invitations, payment structures, shared projects, course exercises, and explicit integrity standards affect participation and coordination?
 - How can participant experience be distinguished from a causal or generalizable outcome?
 
-Existing Persian-language working material includes [Commitment Context](/human-transformation/research-agenda/commitment-context), [Invitation Context](/human-transformation/research-agenda/invitation-context), [Course Experiments](/human-transformation/research-agenda/course-experiments), [Integrity Index](/human-transformation/research-agenda/integrity-index), and [Shared Project](/human-transformation/research-agenda/created-future). These pages preserve field observations and developing hypotheses; their presence does not upgrade their evidence level.
-
 ## 6. Quality of Life
 
 **Current status: Open**

--- a/docs/human-transformation/research-agenda-fa.md
+++ b/docs/human-transformation/research-agenda-fa.md
@@ -100,8 +100,6 @@ permalink: /human-transformation/research-agenda-fa
 - دعوت، ساختار پرداخت، پروژه‌ی مشترک، تجربه‌گری‌های دوره و استانداردهای صریح یکپارچگی چگونه بر مشارکت و هماهنگی اثر می‌گذارند؟
 - چگونه می‌توان تجربه‌ی شرکت‌کننده را از پیامد علّی یا قابل تعمیم جدا کرد؟
 
-مواد کاری موجود به زبان فارسی شامل [بافتمان تعهد](/human-transformation/research-agenda/commitment-context)، [بافتمان دعوت](/human-transformation/research-agenda/invitation-context)، [تجربه‌گری‌های دوره](/human-transformation/research-agenda/course-experiments)، [شاخص یکپارچگی](/human-transformation/research-agenda/integrity-index) و [پروژه‌ی مشترک](/human-transformation/research-agenda/created-future) است. این صفحه‌ها مشاهده‌های میدانی و فرضیه‌های در حال شکل‌گیری را حفظ می‌کنند؛ حضورشان در این برنامه سطح شواهد آن‌ها را بالاتر نمی‌برد.
-
 ## ۶. کیفیت زندگی
 
 **وضعیت فعلی: باز**


### PR DESCRIPTION
## What changed

- moved the five legacy leadership research pages to `/archive/leadership-research/`
- added small archive and leadership-research archive indexes
- removed the archived pages from both current Human Transformation Research Agenda editions
- excluded the archive from primary navigation, site search, and the sitemap
- added a small Archive link to the footer

## Why

The pages were historical working material, but their shared `parent: Research Agenda` metadata caused them to appear beneath Vocora’s research agenda. They should remain accessible without being presented as current research.

## Validation

- `npm test`
- `git diff --check`
- verified no legacy Research Agenda child metadata or old active URLs remain