### PR TITLE
Redesign the content footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -113,14 +113,6 @@ liquid:
 back_to_top: true
 back_to_top_text: "Back to top"
 
-footer_content: >-
-  Copyright &copy; 2023&ndash;2026 Mohammad Bayat.
-  Connect on <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>,
-  <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>, or
-  <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>.
-  Browse the <a href="/archive/">Archive</a>.
-  Website source is available under the MIT license.
-
 last_edit_timestamp: true
 last_edit_time_format: "%b %e %Y at %I:%M %p"
 

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -2,18 +2,20 @@
   {%- include footer_custom.html -%}
 {% endcapture %}
 {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link or site.back_to_top %}
-  <hr>
-  <footer class="text-left" dir="ltr">
-    {% if site.back_to_top %}
-      <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p>
-    {% endif %}
+  <footer class="content-footer text-left" dir="ltr">
+    <div class="content-footer-top">
+      <span class="content-footer-label">OkBayat.com</span>
+      {% if site.back_to_top %}
+        <a class="content-footer-back-to-top" href="#top" id="back-to-top">{{ site.back_to_top_text }} &uarr;</a>
+      {% endif %}
+    </div>
 
-    {{ footer_custom }}
+    {{ footer_custom | strip }}
 
     {% if site.last_edit_timestamp or site.gh_edit_link %}
-      <div class="d-flex mt-2">
+      <div class="content-footer-meta">
         {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-          <p class="text-small text-grey-dk-000 mb-0 mr-2">
+          <p>
             Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
           </p>
         {% endif %}
@@ -24,10 +26,10 @@
           site.gh_edit_branch and
           site.gh_edit_view_mode
         %}
-          <p class="text-small text-grey-dk-000 mb-0">
+          <p>
             <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
-            &nbsp; | &nbsp;
-            All content on this site is published under the <a href="https://www.gnu.org/licenses/fdl.html">GNU Free Documentation License</a>.
+            <span aria-hidden="true">&middot;</span>
+            Content: <a href="https://www.gnu.org/licenses/fdl.html">GNU FDL</a>
           </p>
         {% endif %}
       </div>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,3 +1,27 @@
-{%- if site.footer_content -%}
-  <p class="text-small text-grey-dk-100 mb-0">{{ site.footer_content }}</p>
-{%- endif -%}
+<div class="content-footer-primary">
+  <a class="content-footer-archive" href="{{ '/archive/' | relative_url }}">
+    <span class="content-footer-archive-copy">
+      <span class="content-footer-label">Explore</span>
+      <span class="content-footer-archive-title">Archive</span>
+      <span class="content-footer-archive-description">Earlier research and materials</span>
+    </span>
+    <span class="content-footer-arrow" aria-hidden="true">&rarr;</span>
+  </a>
+
+  <nav class="content-footer-connect" aria-label="Connect">
+    <span class="content-footer-label">Connect</span>
+    <div class="content-footer-links">
+      <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>
+    </div>
+  </nav>
+</div>
+
+<div class="content-footer-identity">
+  <p>&copy; 2023&ndash;2026 Mohammad Bayat</p>
+  <p>
+    <a href="https://github.com/OkBayat/OkBayat.github.io" target="_blank" rel="noopener noreferrer">Website source</a>
+    is available under the MIT License.
+  </p>
+</div>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -50,6 +50,162 @@
   font-size: 0.9rem;
 }
 
+.content-footer {
+  margin-top: $sp-10;
+  padding-top: $sp-5;
+  color: $grey-dk-100;
+  border-top: 2px solid $border-color;
+}
+
+.content-footer-top,
+.content-footer-primary,
+.content-footer-identity,
+.content-footer-meta {
+  display: flex;
+}
+
+.content-footer-top {
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: $sp-4;
+}
+
+.content-footer-label {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: $grey-dk-000;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.content-footer-back-to-top {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.content-footer-primary {
+  flex-direction: column;
+  gap: $sp-5;
+  align-items: stretch;
+}
+
+.content-footer-archive {
+  display: flex;
+  flex: 1 1 60%;
+  gap: $sp-4;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  padding: $sp-4;
+  color: $body-text-color;
+  text-decoration: none;
+  background-color: $feedback-color;
+  border: $border $border-color;
+  border-left: 3px solid $link-color;
+  border-radius: 6px;
+  transition:
+    border-color 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: $body-text-color;
+    text-decoration: none;
+    border-color: $link-color;
+    transform: translateY(-1px);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $link-color;
+    outline-offset: 2px;
+  }
+}
+
+.content-footer-archive-copy {
+  display: block;
+  min-width: 0;
+}
+
+.content-footer-archive-title {
+  display: block;
+  margin-top: $sp-1;
+  font-size: 1.125rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: $body-heading-color;
+}
+
+.content-footer-archive-description {
+  display: block;
+  margin-top: $sp-1;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: $grey-dk-100;
+}
+
+.content-footer-arrow {
+  flex: 0 0 auto;
+  font-size: 1.25rem;
+  color: $link-color;
+}
+
+.content-footer-connect {
+  flex: 1 1 40%;
+  padding: $sp-4 0;
+}
+
+.content-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $sp-2 $sp-4;
+  margin-top: $sp-3;
+  font-size: 0.8125rem;
+}
+
+.content-footer-identity,
+.content-footer-meta {
+  flex-wrap: wrap;
+  gap: $sp-2 $sp-5;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.6875rem;
+  line-height: 1.5;
+
+  p {
+    margin: 0;
+  }
+}
+
+.content-footer-identity {
+  margin-top: $sp-4;
+  padding-bottom: $sp-3;
+}
+
+.content-footer-meta {
+  padding-top: $sp-3;
+  color: $grey-dk-000;
+  border-top: $border $border-color;
+}
+
+@include mq(sm) {
+  .content-footer-primary {
+    flex-direction: row;
+  }
+
+  .content-footer-connect {
+    padding-bottom: $sp-4;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .content-footer-archive {
+    transition: none;
+  }
+}
+
 .mark {
   background-color: rgba($yellow-200, 0.15);
 }

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -8,5 +8,3 @@ permalink: /archive/
 # Archive
 
 This archive preserves historical material that is no longer part of the site's current research, publication, or program pathways.
-
-- [Leadership Research Archive](/archive/leadership-research/) — earlier Persian-language working pages about leadership programs, participation, coordination, and integrity.

--- a/docs/archive/leadership-research/index.md
+++ b/docs/archive/leadership-research/index.md
@@ -9,9 +9,3 @@ permalink: /archive/leadership-research/
 # Leadership Research Archive
 
 These Persian-language pages preserve earlier working observations and developing hypotheses from leadership programs. They are historical records, not current research claims, and are not part of the Human Transformation Research Agenda.
-
-- [بافتمان تعهد](/archive/leadership-research/commitment-context)
-- [بافتمان دعوت](/archive/leadership-research/invitation-context)
-- [تجربه‌گری‌های دوره](/archive/leadership-research/course-experiments)
-- [شاخص یکپارچگی](/archive/leadership-research/integrity-index)
-- [پروژه‌ی مشترک](/archive/leadership-research/created-future)


### PR DESCRIPTION
## What changed

- removed the hand-authored child lists from both Archive index pages so only the automatic child navigation is rendered
- replaced the dense footer paragraph with a structured, responsive footer
- made Archive a prominent destination with its own card and description
- separated social links, site identity, source licensing, page metadata, and content licensing into clear visual levels
- added keyboard focus states and reduced-motion support

## Why

The Archive link was visually buried inside a small paragraph, and manually listed archive children duplicated the theme’s automatic child navigation.

## Validation

- `npm test`
- `git diff --check`
- verified the branch is one commit ahead of `main` with only the six expected files changed

Jekyll rendering was not available locally because Ruby/Bundler is not installed in the workspace; GitHub Actions remains the full build validation.