### PR TITLE
Match the approved footer layout

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -6,21 +6,10 @@
     {{ footer_custom | strip }}
 
     <div class="content-footer-secondary">
-      <div class="content-footer-identity">
-        <span>&copy; 2023&ndash;2026 Mohammad Bayat</span>
-        <span aria-hidden="true">&middot;</span>
-        <a href="https://github.com/OkBayat/OkBayat.github.io" target="_blank" rel="noopener noreferrer">Source code</a>
-        <span aria-hidden="true">&middot;</span>
-        <a href="https://github.com/OkBayat/OkBayat.github.io/blob/main/LICENSE.txt" target="_blank" rel="noopener noreferrer">MIT License</a>
-      </div>
+      <p class="content-footer-copyright">&copy; 2023&ndash;2026 Mohammad Bayat</p>
 
-      {% if site.last_edit_timestamp or site.gh_edit_link %}
-        <div class="content-footer-meta">
-          {% assign has_page_timestamp = false %}
-          {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-            {% assign has_page_timestamp = true %}
-            <span>Updated <span class="d-inline-block">{{ page.last_modified_date | date: "%b %e, %Y" }}</span></span>
-          {% endif %}
+      <nav class="content-footer-meta" aria-label="Page information">
+        {% if site.gh_edit_link %}
           {% if
             site.gh_edit_link and
             site.gh_edit_link_text and
@@ -28,13 +17,18 @@
             site.gh_edit_branch and
             site.gh_edit_view_mode
           %}
-            {% if has_page_timestamp %}<span aria-hidden="true">&middot;</span>{% endif %}
-            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">Edit page</a>
-            <span aria-hidden="true">&middot;</span>
-            <a href="https://www.gnu.org/licenses/fdl.html">Content license</a>
+            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">Edit this page</a>
           {% endif %}
-        </div>
-      {% endif %}
+        {% endif %}
+        <span aria-hidden="true">&middot;</span>
+        <span>Content: <a href="https://www.gnu.org/licenses/fdl.html">GNU FDL</a></span>
+        <span aria-hidden="true">&middot;</span>
+        <span>Source: <a href="https://github.com/OkBayat/OkBayat.github.io/blob/main/LICENSE.txt" target="_blank" rel="noopener noreferrer">MIT</a></span>
+        {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
+          <span aria-hidden="true">&middot;</span>
+          <span>Updated <span class="d-inline-block">{{ page.last_modified_date | date: "%b %e, %Y" }}</span></span>
+        {% endif %}
+      </nav>
     </div>
   </footer>
 {% endif %}

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -3,36 +3,38 @@
 {% endcapture %}
 {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link or site.back_to_top %}
   <footer class="content-footer text-left" dir="ltr">
-    <div class="content-footer-top">
-      <span class="content-footer-label">OkBayat.com</span>
-      {% if site.back_to_top %}
-        <a class="content-footer-back-to-top" href="#top" id="back-to-top">{{ site.back_to_top_text }} &uarr;</a>
-      {% endif %}
-    </div>
-
     {{ footer_custom | strip }}
 
-    {% if site.last_edit_timestamp or site.gh_edit_link %}
-      <div class="content-footer-meta">
-        {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-          <p>
-            Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
-          </p>
-        {% endif %}
-        {% if
-          site.gh_edit_link and
-          site.gh_edit_link_text and
-          site.gh_edit_repository and
-          site.gh_edit_branch and
-          site.gh_edit_view_mode
-        %}
-          <p>
-            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
-            <span aria-hidden="true">&middot;</span>
-            Content: <a href="https://www.gnu.org/licenses/fdl.html">GNU FDL</a>
-          </p>
-        {% endif %}
+    <div class="content-footer-secondary">
+      <div class="content-footer-identity">
+        <span>&copy; 2023&ndash;2026 Mohammad Bayat</span>
+        <span aria-hidden="true">&middot;</span>
+        <a href="https://github.com/OkBayat/OkBayat.github.io" target="_blank" rel="noopener noreferrer">Source code</a>
+        <span aria-hidden="true">&middot;</span>
+        <a href="https://github.com/OkBayat/OkBayat.github.io/blob/main/LICENSE.txt" target="_blank" rel="noopener noreferrer">MIT License</a>
       </div>
-    {% endif %}
+
+      {% if site.last_edit_timestamp or site.gh_edit_link %}
+        <div class="content-footer-meta">
+          {% assign has_page_timestamp = false %}
+          {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
+            {% assign has_page_timestamp = true %}
+            <span>Updated <span class="d-inline-block">{{ page.last_modified_date | date: "%b %e, %Y" }}</span></span>
+          {% endif %}
+          {% if
+            site.gh_edit_link and
+            site.gh_edit_link_text and
+            site.gh_edit_repository and
+            site.gh_edit_branch and
+            site.gh_edit_view_mode
+          %}
+            {% if has_page_timestamp %}<span aria-hidden="true">&middot;</span>{% endif %}
+            <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">Edit page</a>
+            <span aria-hidden="true">&middot;</span>
+            <a href="https://www.gnu.org/licenses/fdl.html">Content license</a>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
   </footer>
 {% endif %}

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,27 +1,13 @@
 <div class="content-footer-primary">
-  <a class="content-footer-archive" href="{{ '/archive/' | relative_url }}">
-    <span class="content-footer-archive-copy">
-      <span class="content-footer-label">Explore</span>
-      <span class="content-footer-archive-title">Archive</span>
-      <span class="content-footer-archive-description">Earlier research and materials</span>
-    </span>
-    <span class="content-footer-arrow" aria-hidden="true">&rarr;</span>
-  </a>
+  <a class="content-footer-brand" href="{{ '/' | relative_url }}">OkBayat.com</a>
 
-  <nav class="content-footer-connect" aria-label="Connect">
-    <span class="content-footer-label">Connect</span>
-    <div class="content-footer-links">
-      <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-      <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>
-    </div>
+  <nav class="content-footer-nav" aria-label="Footer navigation">
+    <a class="content-footer-archive" href="{{ '/archive/' | relative_url }}">Archive</a>
+    <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+    <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>
+    <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>
+    {% if site.back_to_top %}
+      <a class="content-footer-back-to-top" href="#top" id="back-to-top">{{ site.back_to_top_text }} <span aria-hidden="true">&uarr;</span></a>
+    {% endif %}
   </nav>
-</div>
-
-<div class="content-footer-identity">
-  <p>&copy; 2023&ndash;2026 Mohammad Bayat</p>
-  <p>
-    <a href="https://github.com/OkBayat/OkBayat.github.io" target="_blank" rel="noopener noreferrer">Website source</a>
-    is available under the MIT License.
-  </p>
 </div>

--- a/_includes/footer_custom.html
+++ b/_includes/footer_custom.html
@@ -1,13 +1,25 @@
-<div class="content-footer-primary">
-  <a class="content-footer-brand" href="{{ '/' | relative_url }}">OkBayat.com</a>
+<div class="content-footer-main">
+  <div class="content-footer-about">
+    <a class="content-footer-brand" href="{{ '/' | relative_url }}">OkBayat.com</a>
+    <p>Notes on leadership, human transformation, and building.</p>
+  </div>
 
-  <nav class="content-footer-nav" aria-label="Footer navigation">
-    <a class="content-footer-archive" href="{{ '/archive/' | relative_url }}">Archive</a>
-    <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-    <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>
-    <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>
-    {% if site.back_to_top %}
-      <a class="content-footer-back-to-top" href="#top" id="back-to-top">{{ site.back_to_top_text }} <span aria-hidden="true">&uarr;</span></a>
-    {% endif %}
+  <nav class="content-footer-group content-footer-explore" aria-label="Explore">
+    <p class="content-footer-label">Explore</p>
+    <div class="content-footer-links content-footer-explore-links">
+      {% if site.back_to_top %}
+        <a class="content-footer-back-to-top" href="#top" id="back-to-top">{{ site.back_to_top_text }} <span aria-hidden="true">&uarr;</span></a>
+      {% endif %}
+      <a class="content-footer-archive" href="{{ '/archive/' | relative_url }}">Archive <span aria-hidden="true">&rarr;</span></a>
+    </div>
+  </nav>
+
+  <nav class="content-footer-group content-footer-connect" aria-label="Connect">
+    <p class="content-footer-label">Connect</p>
+    <div class="content-footer-links content-footer-connect-links">
+      <a href="https://www.linkedin.com/in/okbayat/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+      <a href="https://github.com/OkBayat" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://www.instagram.com/OkBayat" target="_blank" rel="noopener noreferrer">Instagram</a>
+    </div>
   </nav>
 </div>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -52,22 +52,22 @@
 
 .content-footer {
   margin-top: $sp-10;
-  padding: $sp-5 0 $sp-3;
+  padding: $sp-7 0 0;
   color: $grey-dk-100;
+  background-color: $body-background-color;
   border-top: $border $border-color;
 }
 
-.content-footer-primary,
-.content-footer-secondary,
-.content-footer-nav,
-.content-footer-identity,
-.content-footer-meta {
-  display: flex;
+.content-footer-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1.75fr) minmax(7.5rem, 0.85fr) minmax(9rem, 0.95fr);
+  gap: $sp-6;
+  padding-bottom: $sp-7;
 }
 
 .content-footer-brand {
-  flex: 0 0 auto;
-  font-size: 0.8125rem;
+  display: inline-block;
+  font-size: 1rem;
   font-weight: 600;
   color: $body-heading-color;
   text-decoration: none;
@@ -78,42 +78,72 @@
   }
 }
 
-.content-footer-primary {
+.content-footer-about p {
+  max-width: 27rem;
+  margin: $sp-2 0 0;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: $grey-dk-100;
+}
+
+.content-footer-label {
+  margin: 0 0 $sp-4;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  color: $grey-dk-000;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+}
+
+.content-footer-links {
+  display: flex;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.content-footer-explore-links {
+  flex-direction: column;
+  gap: $sp-3;
+  align-items: flex-start;
+}
+
+.content-footer-back-to-top {
+  color: $body-heading-color;
+  text-decoration-color: $border-color;
+}
+
+.content-footer-connect-links {
+  flex-wrap: wrap;
+  gap: $sp-3 $sp-5;
+  align-items: flex-start;
+}
+
+.content-footer-secondary {
+  display: flex;
   flex-wrap: wrap;
   gap: $sp-3 $sp-6;
   align-items: baseline;
   justify-content: space-between;
-}
-
-.content-footer-archive {
-  font-weight: 600;
-}
-
-.content-footer-nav {
-  flex-wrap: wrap;
-  gap: $sp-2 $sp-5;
-  align-items: baseline;
-  font-size: 0.8125rem;
-}
-
-.content-footer-secondary {
-  flex-wrap: wrap;
-  gap: $sp-2 $sp-6;
-  align-items: center;
-  justify-content: space-between;
-  margin-top: $sp-4;
-  padding-top: $sp-3;
-  font-size: 0.6875rem;
+  padding: $sp-5 0 $sp-2;
+  font-size: 0.75rem;
   line-height: 1.5;
   color: $grey-dk-000;
   border-top: $border $border-color;
 }
 
-.content-footer-identity,
+.content-footer-copyright {
+  margin: 0;
+  color: $body-heading-color;
+}
+
 .content-footer-meta {
+  display: flex;
   flex-wrap: wrap;
   gap: $sp-1 $sp-2;
-  align-items: center;
+  align-items: baseline;
+  justify-content: flex-end;
 }
 
 .content-footer a:focus-visible {
@@ -122,13 +152,38 @@
 }
 
 @media (max-width: 31.25rem) {
-  .content-footer-primary,
-  .content-footer-secondary {
-    align-items: flex-start;
+  .content-footer {
+    padding-top: $sp-6;
+  }
+
+  .content-footer-main {
+    grid-template-columns: 1fr;
+    gap: $sp-6;
+    padding-bottom: $sp-6;
+  }
+
+  .content-footer-label {
+    margin-bottom: $sp-3;
   }
 
   .content-footer-secondary {
+    align-items: flex-start;
     flex-direction: column;
+    padding-top: $sp-4;
+  }
+
+  .content-footer-meta {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 49.99rem) {
+  body {
+    padding-bottom: 0;
+  }
+
+  .sidebar-social-footer {
+    display: none;
   }
 }
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -52,157 +52,83 @@
 
 .content-footer {
   margin-top: $sp-10;
-  padding-top: $sp-5;
+  padding: $sp-5 0 $sp-3;
   color: $grey-dk-100;
-  border-top: 2px solid $border-color;
+  border-top: $border $border-color;
 }
 
-.content-footer-top,
 .content-footer-primary,
+.content-footer-secondary,
+.content-footer-nav,
 .content-footer-identity,
 .content-footer-meta {
   display: flex;
 }
 
-.content-footer-top {
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: $sp-4;
-}
-
-.content-footer-label {
-  display: block;
-  font-size: 0.6875rem;
+.content-footer-brand {
+  flex: 0 0 auto;
+  font-size: 0.8125rem;
   font-weight: 600;
-  line-height: 1.2;
-  color: $grey-dk-000;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.content-footer-back-to-top {
-  font-size: 0.75rem;
-  font-weight: 500;
+  color: $body-heading-color;
   text-decoration: none;
+
+  &:hover {
+    color: $link-color;
+    text-decoration: none;
+  }
 }
 
 .content-footer-primary {
-  flex-direction: column;
-  gap: $sp-5;
-  align-items: stretch;
+  flex-wrap: wrap;
+  gap: $sp-3 $sp-6;
+  align-items: baseline;
+  justify-content: space-between;
 }
 
 .content-footer-archive {
-  display: flex;
-  flex: 1 1 60%;
-  gap: $sp-4;
-  align-items: center;
-  justify-content: space-between;
-  min-width: 0;
-  padding: $sp-4;
-  color: $body-text-color;
-  text-decoration: none;
-  background-color: $feedback-color;
-  border: $border $border-color;
-  border-left: 3px solid $link-color;
-  border-radius: 6px;
-  transition:
-    border-color 0.15s ease,
-    transform 0.15s ease;
-
-  &:hover,
-  &:focus-visible {
-    color: $body-text-color;
-    text-decoration: none;
-    border-color: $link-color;
-    transform: translateY(-1px);
-  }
-
-  &:focus-visible {
-    outline: 2px solid $link-color;
-    outline-offset: 2px;
-  }
-}
-
-.content-footer-archive-copy {
-  display: block;
-  min-width: 0;
-}
-
-.content-footer-archive-title {
-  display: block;
-  margin-top: $sp-1;
-  font-size: 1.125rem;
   font-weight: 600;
-  line-height: 1.3;
-  color: $body-heading-color;
 }
 
-.content-footer-archive-description {
-  display: block;
-  margin-top: $sp-1;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  color: $grey-dk-100;
-}
-
-.content-footer-arrow {
-  flex: 0 0 auto;
-  font-size: 1.25rem;
-  color: $link-color;
-}
-
-.content-footer-connect {
-  flex: 1 1 40%;
-  padding: $sp-4 0;
-}
-
-.content-footer-links {
-  display: flex;
+.content-footer-nav {
   flex-wrap: wrap;
-  gap: $sp-2 $sp-4;
-  margin-top: $sp-3;
+  gap: $sp-2 $sp-5;
+  align-items: baseline;
   font-size: 0.8125rem;
 }
 
-.content-footer-identity,
-.content-footer-meta {
+.content-footer-secondary {
   flex-wrap: wrap;
-  gap: $sp-2 $sp-5;
+  gap: $sp-2 $sp-6;
   align-items: center;
   justify-content: space-between;
+  margin-top: $sp-4;
+  padding-top: $sp-3;
   font-size: 0.6875rem;
   line-height: 1.5;
-
-  p {
-    margin: 0;
-  }
-}
-
-.content-footer-identity {
-  margin-top: $sp-4;
-  padding-bottom: $sp-3;
-}
-
-.content-footer-meta {
-  padding-top: $sp-3;
   color: $grey-dk-000;
   border-top: $border $border-color;
 }
 
-@include mq(sm) {
-  .content-footer-primary {
-    flex-direction: row;
-  }
-
-  .content-footer-connect {
-    padding-bottom: $sp-4;
-  }
+.content-footer-identity,
+.content-footer-meta {
+  flex-wrap: wrap;
+  gap: $sp-1 $sp-2;
+  align-items: center;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .content-footer-archive {
-    transition: none;
+.content-footer a:focus-visible {
+  outline: 2px solid $link-color;
+  outline-offset: 3px;
+}
+
+@media (max-width: 31.25rem) {
+  .content-footer-primary,
+  .content-footer-secondary {
+    align-items: flex-start;
+  }
+
+  .content-footer-secondary {
+    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
## What changed

- matched the approved footer concept with a light-background, three-column desktop layout
- restored the site description and separate Explore and Connect sections
- placed Back to top and Archive in the Explore column, with the approved arrow treatments
- matched the compact legal row: copyright, edit link, content license, source license, and update date
- stacked the same hierarchy cleanly on mobile and removed the duplicate mobile social-icon footer

## Why

The earlier implementation simplified the concept too far and no longer matched the approved design. This revision treats the concept as the visual specification while preserving the site's existing white color scheme.

## Validation

- `npm test` passes (Stylelint and Prettier)
- `git diff --check` passes
- exactly the same three footer files remain in scope
- GitHub Actions performs the complete Jekyll build and HTML validation