### PR TITLE
Remove Footer language override

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -2,7 +2,7 @@
   {%- include footer_custom.html -%}
 {% endcapture %}
 {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link or site.back_to_top %}
-  <footer class="content-footer text-left" lang="en" dir="ltr">
+  <footer class="content-footer text-left" dir="ltr">
     {{ footer_custom | strip }}
 
     <div class="content-footer-secondary">

--- a/scripts/validate_site_integrity.js
+++ b/scripts/validate_site_integrity.js
@@ -385,7 +385,6 @@ function validateGeneratedSite(siteDirectory) {
       for (const [name, tag] of [
         ["shared site shell", shellTag],
         ["sidebar", sidebarTag],
-        ["footer", footerTag],
       ]) {
         if (!tag) continue
         const language = htmlAttribute(tag, "lang")
@@ -393,6 +392,16 @@ function validateGeneratedSite(siteDirectory) {
         if (language !== "en" || direction !== "ltr") {
           errors.add(
             `_site/${label}: ${name} must stay lang=en and dir=ltr, found lang=${language || "none"} dir=${direction || "none"}`
+          )
+        }
+      }
+
+      if (footerTag) {
+        const footerLanguage = htmlAttribute(footerTag, "lang")
+        const footerDirection = htmlAttribute(footerTag, "dir")
+        if (footerLanguage || footerDirection !== "ltr") {
+          errors.add(
+            `_site/${label}: footer must omit lang and stay dir=ltr, found lang=${footerLanguage || "none"} dir=${footerDirection || "none"}`
           )
         }
       }


### PR DESCRIPTION
## What changed

- remove the explicit `lang="en"` attribute from the shared Footer
- keep `dir="ltr"` so Footer layout remains left-to-right on Persian pages
- update the site-integrity validator to require this exact boundary

## Why

The explicit Footer language override changed the Latin font rendering on Persian pages and made Footer text appear bold. The Footer should preserve its existing visual treatment while only the article content uses Persian/RTL styling.

## Validation

- `npm test`
- `git diff --check`
- source integrity validation passes across 162 pages

The full Jekyll build and generated-HTML validation run in GitHub Actions.