### PR TITLE
Scope Persian typography to article content

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -20,7 +20,7 @@
     unicode-bidi: isolate;
   }
 
-  &[dir="rtl"] {
+  &[dir="rtl"] > main {
     text-align: justify;
     font-family: IRANSans, $body-font-family;
     font-weight: 300;


### PR DESCRIPTION
## What changed

- scope the RTL article typography selector to the direct `main` child
- keep the shared Footer outside the Persian font, weight, and justification rules

## Why

The Footer is rendered inside `.main-content` but outside `<main>`. The previous `.main-content[dir="rtl"]` selector applied inheritable Persian typography to the Footer as well. Targeting `.main-content[dir="rtl"] > main` limits those rules to the article content.

## Validation

- `npm test`
- `git diff --check`
- source integrity validation passed across 162 pages

The full Jekyll build runs in GitHub Actions.