### PR TITLE
Refine theme toggle placement and prevent theme flash

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -4,8 +4,8 @@
   {% else %}
     <div></div>
   {% endif %}
-  {% include header_custom.html %}
   {% if site.aux_links %}
     {% include components/aux_nav.html %}
   {% endif %}
+  {% include header_custom.html %}
 </div>

--- a/_includes/components/theme_toggle.html
+++ b/_includes/components/theme_toggle.html
@@ -14,37 +14,54 @@
   (function () {
     var storageKey = "okbayat-theme";
 
-    function getPreferredTheme() {
-      var saved = localStorage.getItem(storageKey);
-      return saved === "dark" ? "dark" : "light";
+    function currentTheme() {
+      return window.jtdTheme === "dark" ||
+        document.documentElement.dataset.theme === "dark"
+        ? "dark"
+        : "light";
     }
 
-    function applyTheme(theme) {
-      if (window.jtd && window.jtd.setTheme) {
-        window.jtd.setTheme(theme);
-      }
-      document.documentElement.dataset.theme = theme;
-
-      var button = document.getElementById("theme-toggle");
-      if (button) {
-        var dark = theme === "dark";
-        button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-        button.title = dark ? "Light mode" : "Dark mode";
-      }
-    }
-
-    window.jtdTheme = getPreferredTheme();
-
-    document.addEventListener("DOMContentLoaded", function () {
-      applyTheme(window.jtdTheme);
-
+    function updateButton(theme) {
       var button = document.getElementById("theme-toggle");
       if (!button) return;
 
+      var dark = theme === "dark";
+      button.setAttribute(
+        "aria-label",
+        dark ? "Switch to light mode" : "Switch to dark mode"
+      );
+      button.title = dark ? "Light mode" : "Dark mode";
+    }
+
+    function applyTheme(theme) {
+      var stylesheet = document.getElementById("jtd-theme-stylesheet");
+
+      window.jtdTheme = theme;
+      document.documentElement.dataset.theme = theme;
+
+      if (stylesheet) {
+        stylesheet.href =
+          "{{ '/assets/css/just-the-docs-' | relative_url }}" + theme + ".css";
+      } else if (window.jtd && window.jtd.setTheme) {
+        window.jtd.setTheme(theme);
+      }
+
+      try {
+        window.localStorage.setItem(storageKey, theme);
+      } catch (error) {
+        // The selected theme still applies for this page when storage is unavailable.
+      }
+
+      updateButton(theme);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+      var button = document.getElementById("theme-toggle");
+      if (!button) return;
+
+      updateButton(currentTheme());
       button.addEventListener("click", function () {
-        window.jtdTheme = window.jtdTheme === "dark" ? "light" : "dark";
-        localStorage.setItem(storageKey, window.jtdTheme);
-        applyTheme(window.jtdTheme);
+        applyTheme(currentTheme() === "dark" ? "light" : "dark");
       });
     });
   })();

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,43 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+  <script>
+    (function () {
+      var storageKey = "okbayat-theme";
+      var theme = "light";
+
+      try {
+        if (window.localStorage.getItem(storageKey) === "dark") {
+          theme = "dark";
+        }
+      } catch (error) {
+        theme = "light";
+      }
+
+      var root = document.documentElement;
+      root.dataset.theme = theme;
+      root.style.visibility = "hidden";
+      window.jtdTheme = theme;
+
+      var stylesheet = document.createElement("link");
+      stylesheet.rel = "stylesheet";
+      stylesheet.id = "jtd-theme-stylesheet";
+      stylesheet.href =
+        "{{ '/assets/css/just-the-docs-' | relative_url }}" + theme + ".css";
+
+      function revealPage() {
+        root.style.visibility = "";
+      }
+
+      stylesheet.addEventListener("load", revealPage);
+      stylesheet.addEventListener("error", revealPage);
+      window.setTimeout(revealPage, 3000);
+      document.head.appendChild(stylesheet);
+    })();
+  </script>
+  <noscript>
+    <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-light.css' | relative_url }}">
+  </noscript>
 
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-head-nav.css' | relative_url }}" id="jtd-head-nav-stylesheet">
 
@@ -27,10 +63,10 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
+      function gtag(){window.dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      {% for ga_property in ga_tracking_ids %}
+      {% for ga_property in site.ga_tracking %}
         gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
       {% endfor %}
     </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -63,10 +63,10 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){window.dataLayer.push(arguments);}
+      function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      {% for ga_property in site.ga_tracking %}
+      {% for ga_property in ga_tracking_ids %}
         gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
       {% endfor %}
     </script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -10,21 +10,21 @@
   align-self: center;
   align-items: center;
   justify-content: center;
-  margin-left: 1rem;
+  margin-right: .5rem;
+  margin-left: .25rem;
   padding: 0;
   cursor: pointer;
   color: inherit;
   background-color: transparent;
-  border: 1px solid rgba(128, 128, 128, .45);
+  border: 0;
   border-radius: 999px;
   transform: translateY(1px);
-  transition: background-color .15s ease, border-color .15s ease, opacity .15s ease;
+  transition: background-color .15s ease, opacity .15s ease;
 }
 
 .theme-toggle:hover,
 .theme-toggle:focus-visible {
   background-color: rgba(128, 128, 128, .1);
-  border-color: currentColor;
 }
 
 .theme-toggle:focus-visible {
@@ -62,7 +62,8 @@
 
 @media (max-width: 49.99rem) {
   .theme-toggle {
-    margin-left: .75rem;
+    margin-right: .75rem;
+    margin-left: .25rem;
   }
 }
 </style>


### PR DESCRIPTION
## What changed

- moved the theme toggle to the right of the `Website source` link
- removed the toggle border while preserving the rounded hover and focus surface
- adjusted horizontal spacing to match the approved header layout
- bootstrapped the saved theme in the document head before the page renders
- stopped the toggle component from reapplying the initial theme after `DOMContentLoaded`
- kept light as the default unless the user has explicitly saved dark mode

## Why

The control should match the approved header composition and must not briefly render the light theme before switching to a saved dark theme during navigation.

## Implementation details

- the correct theme stylesheet is selected before first paint
- the page stays hidden only until that stylesheet loads, with an error/timeout fallback
- no device color-scheme preference is used
- the existing localStorage preference remains the source of truth