### PR TITLE
Refine theme toggle placement and prevent theme flash

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -4,8 +4,8 @@
   {% else %}
     <div></div>
   {% endif %}
-  {% include header_custom.html %}
   {% if site.aux_links %}
     {% include components/aux_nav.html %}
   {% endif %}
+  {% include header_custom.html %}
 </div>

--- a/_includes/components/theme_toggle.html
+++ b/_includes/components/theme_toggle.html
@@ -1,4 +1,4 @@
-<button class="theme-toggle" type="button" id="theme-toggle" aria-label="Switch to dark mode" title="Switch to dark mode">
+<button class="theme-toggle" type="button" id="theme-toggle" aria-label="Switch to dark mode" aria-pressed="false" title="Switch to dark mode">
   <span class="theme-toggle-icon" aria-hidden="true">
     <svg class="theme-icon theme-icon-sun" viewBox="0 0 24 24">
       <circle cx="12" cy="12" r="4"></circle>
@@ -13,39 +13,44 @@
 <script>
   (function () {
     var storageKey = "okbayat-theme";
+    var button = document.getElementById("theme-toggle");
 
-    function getPreferredTheme() {
-      var saved = localStorage.getItem(storageKey);
-      return saved === "dark" ? "dark" : "light";
+    function updateButton(theme) {
+      var dark = theme === "dark";
+      button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+      button.setAttribute("aria-pressed", dark ? "true" : "false");
+      button.title = dark ? "Switch to light mode" : "Switch to dark mode";
     }
 
     function applyTheme(theme) {
-      if (window.jtd && window.jtd.setTheme) {
-        window.jtd.setTheme(theme);
-      }
-      document.documentElement.dataset.theme = theme;
+      window.jtdTheme = theme;
+      document.documentElement.setAttribute("data-theme", theme);
+      document.documentElement.style.colorScheme = theme;
 
-      var button = document.getElementById("theme-toggle");
-      if (button) {
-        var dark = theme === "dark";
-        button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-        button.title = dark ? "Light mode" : "Dark mode";
+      if (window.jtd && typeof window.jtd.setTheme === "function") {
+        window.jtd.setTheme(theme);
+      } else {
+        var stylesheet = document.getElementById("jtd-theme-stylesheet");
+        if (stylesheet) {
+          stylesheet.href = "{{ '/assets/css/just-the-docs-' | relative_url }}" + theme + ".css";
+        }
       }
+
+      try {
+        window.localStorage.setItem(storageKey, theme);
+      } catch (error) {
+        // The selected theme still applies for the current page.
+      }
+
+      updateButton(theme);
     }
 
-    window.jtdTheme = getPreferredTheme();
+    if (!button) return;
 
-    document.addEventListener("DOMContentLoaded", function () {
-      applyTheme(window.jtdTheme);
+    updateButton(window.jtdTheme === "dark" ? "dark" : "light");
 
-      var button = document.getElementById("theme-toggle");
-      if (!button) return;
-
-      button.addEventListener("click", function () {
-        window.jtdTheme = window.jtdTheme === "dark" ? "light" : "dark";
-        localStorage.setItem(storageKey, window.jtdTheme);
-        applyTheme(window.jtdTheme);
-      });
+    button.addEventListener("click", function () {
+      applyTheme(window.jtdTheme === "dark" ? "light" : "dark");
     });
   })();
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,36 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 
-  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}">
+  <script>
+    (function () {
+      var theme = "light";
+
+      try {
+        if (window.localStorage.getItem("okbayat-theme") === "dark") {
+          theme = "dark";
+        }
+      } catch (error) {
+        theme = "light";
+      }
+
+      window.jtdTheme = theme;
+      document.documentElement.setAttribute("data-theme", theme);
+      document.documentElement.style.colorScheme = theme;
+      document.documentElement.style.backgroundColor = theme === "dark" ? "#27262b" : "#fff";
+
+      var themeStylesheet = document.createElement("link");
+      themeStylesheet.rel = "stylesheet";
+      themeStylesheet.id = "jtd-theme-stylesheet";
+      themeStylesheet.href = "{{ '/assets/css/just-the-docs-' | relative_url }}" + theme + ".css";
+      themeStylesheet.onload = function () {
+        document.documentElement.style.removeProperty("background-color");
+      };
+      document.head.appendChild(themeStylesheet);
+    })();
+  </script>
+  <noscript>
+    <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-light.css' | relative_url }}">
+  </noscript>
 
   <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-head-nav.css' | relative_url }}" id="jtd-head-nav-stylesheet">
 

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -2,6 +2,10 @@
 <link rel="stylesheet" href="/assets/css/audio.css">
 
 <style>
+.main-header .aux-nav {
+  padding-right: 0;
+}
+
 .theme-toggle {
   display: inline-flex;
   flex: 0 0 auto;
@@ -10,21 +14,22 @@
   align-self: center;
   align-items: center;
   justify-content: center;
-  margin-left: 1rem;
+  margin-right: .5rem;
+  margin-left: 0;
   padding: 0;
   cursor: pointer;
   color: inherit;
   background-color: transparent;
-  border: 1px solid rgba(128, 128, 128, .45);
-  border-radius: 999px;
+  border: 0;
+  border-radius: 50%;
+  appearance: none;
   transform: translateY(1px);
-  transition: background-color .15s ease, border-color .15s ease, opacity .15s ease;
+  transition: background-color .15s ease, opacity .15s ease;
 }
 
 .theme-toggle:hover,
 .theme-toggle:focus-visible {
   background-color: rgba(128, 128, 128, .1);
-  border-color: currentColor;
 }
 
 .theme-toggle:focus-visible {
@@ -62,7 +67,8 @@
 
 @media (max-width: 49.99rem) {
   .theme-toggle {
-    margin-left: .75rem;
+    margin-right: .5rem;
+    margin-left: 0;
   }
 }
 </style>


### PR DESCRIPTION
## What changed

- moved the theme toggle to the right of the Website source link
- removed the toggle border while retaining its circular hover and focus shape
- matched the header spacing with explicit left/right margins and removed the extra auxiliary-nav right padding
- initialized the saved theme before the main stylesheet is requested
- removed the DOMContentLoaded theme re-application that caused light mode to flash before dark mode
- kept light as the default when the user has not explicitly selected dark mode

## Why

The header control should match the approved layout and a saved dark theme must render correctly from the first paint on every page navigation.

## Validation

- branch is limited to the shared header, theme bootstrap, toggle component, and toggle styles
- default remains light; only an explicit saved `dark` preference selects the dark stylesheet
- full Jekyll, JavaScript/CSS, and generated-HTML validation runs in GitHub Actions