### PR TITLE
Remove Google Analytics

### DIFF
--- a/_includes/google-tag.html
+++ b/_includes/google-tag.html
@@ -1,9 +1,0 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-HEMZ8BRTY6"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-HEMZ8BRTY6');
-</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,12 +1,11 @@
 {%- comment -%}
   Include as: {%- include head.html -%}
-  Depends on: site.ga_tracking, site.ga_tracking_anonymize_ip,
-    site.search_enabled, site.static_files, site.favicon_ico.
+  Depends on: site.search_enabled, site.static_files, site.favicon_ico.
   Results in: HTML for the head element.
   Includes:
     css/activation.scss.liquid, head_custom.html.
   Overwrites:
-    ga_tracking_ids, ga_property, file, favicon.
+    file, favicon.
   Should not be cached, because included files depend on page.
 {%- endcomment -%}
 
@@ -50,20 +49,6 @@
   <style id="jtd-nav-activation">
   {% include css/activation.scss.liquid %}
   </style>
-
-  {% if site.ga_tracking != nil %}
-    {% assign ga_tracking_ids = site.ga_tracking | split: "," %}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      {% for ga_property in ga_tracking_ids %}
-        gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
-      {% endfor %}
-    </script>
-  {% endif %}
 
   {% if site.search_enabled != false %}
     <script src="{{ '/assets/js/vendor/lunr.min.js' | relative_url }}"></script>

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -72,5 +72,3 @@
   }
 }
 </style>
-
-{% include google-tag.html %}


### PR DESCRIPTION
## Summary
- remove the active Google Analytics tag and measurement ID
- remove the dormant theme-level Google Analytics integration
- leave the rest of the site unchanged

## Validation
- site integrity validator passed for 162 source pages
- Prettier and Stylelint passed
- repository search confirms no Google Analytics identifiers or loader references remain

This PR intentionally does not include the separate privacy, consent, or copyright audit recommendations.