### PR TITLE
Fix theme toggle switching

### DIFF
--- a/_includes/components/theme_toggle.html
+++ b/_includes/components/theme_toggle.html
@@ -17,23 +17,28 @@
 
     function updateButton(theme) {
       var dark = theme === "dark";
-      button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+      button.setAttribute(
+        "aria-label",
+        dark ? "Switch to light mode" : "Switch to dark mode"
+      );
       button.setAttribute("aria-pressed", dark ? "true" : "false");
       button.title = dark ? "Switch to light mode" : "Switch to dark mode";
     }
 
     function applyTheme(theme) {
+      var stylesheet = document.getElementById("jtd-theme-stylesheet");
+
       window.jtdTheme = theme;
       document.documentElement.setAttribute("data-theme", theme);
       document.documentElement.style.colorScheme = theme;
 
-      if (window.jtd && typeof window.jtd.setTheme === "function") {
+      if (stylesheet) {
+        stylesheet.href =
+          "{{ '/assets/css/just-the-docs-' | relative_url }}" +
+          theme +
+          ".css";
+      } else if (window.jtd && typeof window.jtd.setTheme === "function") {
         window.jtd.setTheme(theme);
-      } else {
-        var stylesheet = document.getElementById("jtd-theme-stylesheet");
-        if (stylesheet) {
-          stylesheet.href = "{{ '/assets/css/just-the-docs-' | relative_url }}" + theme + ".css";
-        }
       }
 
       try {


### PR DESCRIPTION
## What changed

- fixed the dark/light toggle so it updates the dedicated `#jtd-theme-stylesheet` directly
- kept the existing localStorage persistence, initial light default, icon state, and accessibility attributes
- left the now-correct header spacing unchanged

## Root cause

The previous implementation called `jtd.setTheme()` first. That helper changes the first stylesheet it finds in the document rather than the dedicated theme stylesheet. After the head-loading changes, stylesheet order was no longer a safe assumption, so clicking the toggle could update the wrong stylesheet and leave the visual theme unchanged.

## Validation

- branch contains one focused change to the theme-toggle component
- direct stylesheet targeting is independent of stylesheet order
- fallback to `jtd.setTheme()` remains only when the dedicated stylesheet is unavailable