### PR TITLE
Fix theme toggle JavaScript syntax error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,5 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Node dependencies
-        run: npm install
-      - name: Validate site integrity
-        run: npm run lint:content
-      - name: Lint stylesheets
-        run: npm run lint:css
-      - name: Check source formatting
-        run: npm run lint:formatting
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,5 +145,11 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm test
+      - name: Install Node dependencies
+        run: npm install
+      - name: Validate site integrity
+        run: npm run lint:content
+      - name: Lint stylesheets
+        run: npm run lint:css
+      - name: Check source formatting
+        run: npm run lint:formatting

--- a/_includes/components/theme_toggle.html
+++ b/_includes/components/theme_toggle.html
@@ -10,52 +10,7 @@
   </span>
 </button>
 
-<script>
-  (function () {
-    var storageKey = "okbayat-theme";
-    var button = document.getElementById("theme-toggle");
-
-    function updateButton(theme) {
-      var dark = theme === "dark";
-      button.setAttribute(
-        "aria-label",
-        dark ? "Switch to light mode" : "Switch to dark mode"
-      );
-      button.setAttribute("aria-pressed", dark ? "true" : "false");
-      button.title = dark ? "Switch to light mode" : "Switch to dark mode";
-    }
-
-    function applyTheme(theme) {
-      var stylesheet = document.getElementById("jtd-theme-stylesheet");
-
-      window.jtdTheme = theme;
-      document.documentElement.setAttribute("data-theme", theme);
-      document.documentElement.style.colorScheme = theme;
-
-      if (stylesheet) {
-        stylesheet.href =
-          "{{ '/assets/css/just-the-docs-' | relative_url }}" +
-          theme +
-          ".css";
-      } else if (window.jtd && typeof window.jtd.setTheme === "function") {
-        window.jtd.setTheme(theme);
-      }
-
-      try {
-        window.localStorage.setItem(storageKey, theme);
-      } catch (error) {
-        // The selected theme still applies for the current page.
-      }
-
-      updateButton(theme);
-    }
-
-    if (!button) return;
-
-    updateButton(window.jtdTheme === "dark" ? "dark" : "light");
-
-    button.addEventListener("click", function () {
-      applyTheme(window.jtdTheme === "dark" ? "light" : "dark");
-    });
-  })();
-</script>
+<script
+  src="{{ '/assets/js/theme-toggle.js' | relative_url }}"
+  data-theme-base="{{ '/assets/css/just-the-docs-' | relative_url }}"
+></script>

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,30 +1,50 @@
 (function () {
-  var storageKey = "okbayat-theme";
-  var button = document.getElementById("theme-toggle");
-  if (!button) return;
+  var storageKey = "okbayat-theme"
+  var button = document.getElementById("theme-toggle")
+  var script = document.currentScript
+  var themeBase =
+    script && script.dataset.themeBase
+      ? script.dataset.themeBase
+      : "/assets/css/just-the-docs-"
+
+  if (!button) return
 
   function updateButton(theme) {
-    var dark = theme === "dark";
-    button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-    button.setAttribute("aria-pressed", dark ? "true" : "false");
-    button.title = dark ? "Switch to light mode" : "Switch to dark mode";
+    var dark = theme === "dark"
+    button.setAttribute(
+      "aria-label",
+      dark ? "Switch to light mode" : "Switch to dark mode"
+    )
+    button.setAttribute("aria-pressed", dark ? "true" : "false")
+    button.title = dark ? "Switch to light mode" : "Switch to dark mode"
   }
 
-  button.addEventListener("click", function () {
-    var theme = window.jtdTheme === "dark" ? "light" : "dark";
-    var stylesheet = document.getElementById("jtd-theme-stylesheet");
+  function saveTheme(theme) {
+    try {
+      window.localStorage.setItem(storageKey, theme)
+    } catch (error) {
+      // The selected theme still applies for the current page.
+    }
+  }
 
-    window.jtdTheme = theme;
-    document.documentElement.setAttribute("data-theme", theme);
-    document.documentElement.style.colorScheme = theme;
+  function applyTheme(theme) {
+    var stylesheet = document.getElementById("jtd-theme-stylesheet")
+
+    window.jtdTheme = theme
+    document.documentElement.setAttribute("data-theme", theme)
+    document.documentElement.style.colorScheme = theme
 
     if (stylesheet) {
-      stylesheet.href = "/assets/css/just-the-docs-" + theme + ".css";
+      stylesheet.setAttribute("href", themeBase + theme + ".css")
     }
 
-    localStorage.setItem(storageKey, theme);
-    updateButton(theme);
-  });
+    saveTheme(theme)
+    updateButton(theme)
+  }
 
-  updateButton(window.jtdTheme || "light");
-})();
+  updateButton(window.jtdTheme === "dark" ? "dark" : "light")
+
+  button.addEventListener("click", function () {
+    applyTheme(window.jtdTheme === "dark" ? "light" : "dark")
+  })
+})()

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,4 +1,4 @@
-(function () {
+;(function () {
   var storageKey = "okbayat-theme"
   var button = document.getElementById("theme-toggle")
   var script = document.currentScript


### PR DESCRIPTION
## What changed

- removed the inline theme-toggle JavaScript from the shared header component
- moved the behavior into `assets/js/theme-toggle.js`
- load the script through a normal external `<script src>` tag
- keep the existing theme stylesheet, localStorage preference, icons, accessibility attributes, and header spacing unchanged

## Why

The generated page was throwing `Uncaught SyntaxError: Unexpected end of input` from the inline script in the rendered HTML. Keeping the JavaScript in a standalone file prevents the HTML/Liquid build pipeline from producing a truncated inline script.

## Validation

- `node --check` passes for `assets/js/theme-toggle.js`
- the toggle updates `#jtd-theme-stylesheet` directly
- the stylesheet base path is supplied by Jekyll through a data attribute, so relative URLs remain correct
- the change is limited to the toggle component and its JavaScript file