### PR TITLE
Fix theme toggle formatting

### DIFF
--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,30 +1,33 @@
-(function () {
-  var storageKey = "okbayat-theme";
-  var button = document.getElementById("theme-toggle");
-  if (!button) return;
+;(function () {
+  var storageKey = "okbayat-theme"
+  var button = document.getElementById("theme-toggle")
+  if (!button) return
 
   function updateButton(theme) {
-    var dark = theme === "dark";
-    button.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
-    button.setAttribute("aria-pressed", dark ? "true" : "false");
-    button.title = dark ? "Switch to light mode" : "Switch to dark mode";
+    var dark = theme === "dark"
+    button.setAttribute(
+      "aria-label",
+      dark ? "Switch to light mode" : "Switch to dark mode"
+    )
+    button.setAttribute("aria-pressed", dark ? "true" : "false")
+    button.title = dark ? "Switch to light mode" : "Switch to dark mode"
   }
 
   button.addEventListener("click", function () {
-    var theme = window.jtdTheme === "dark" ? "light" : "dark";
-    var stylesheet = document.getElementById("jtd-theme-stylesheet");
+    var theme = window.jtdTheme === "dark" ? "light" : "dark"
+    var stylesheet = document.getElementById("jtd-theme-stylesheet")
 
-    window.jtdTheme = theme;
-    document.documentElement.setAttribute("data-theme", theme);
-    document.documentElement.style.colorScheme = theme;
+    window.jtdTheme = theme
+    document.documentElement.setAttribute("data-theme", theme)
+    document.documentElement.style.colorScheme = theme
 
     if (stylesheet) {
-      stylesheet.href = "/assets/css/just-the-docs-" + theme + ".css";
+      stylesheet.href = "/assets/css/just-the-docs-" + theme + ".css"
     }
 
-    localStorage.setItem(storageKey, theme);
-    updateButton(theme);
-  });
+    localStorage.setItem(storageKey, theme)
+    updateButton(theme)
+  })
 
-  updateButton(window.jtdTheme || "light");
-})();
+  updateButton(window.jtdTheme || "light")
+})()


### PR DESCRIPTION
## Summary
- format `assets/js/theme-toggle.js` with the repository's configured Prettier version and rules
- restore the `Test CSS and JS` CI check that failed after the theme-toggle change reached `main`
- keep the toggle logic and behavior unchanged

## Root cause
CI run 1766 failed only in `lint:formatting`; Prettier reported `assets/js/theme-toggle.js` as unformatted. The other 27 jobs passed.

## Validation
- `npm test`
- `node --check assets/js/theme-toggle.js`
- `git diff --check`

This is intentionally separate from PR #65, which only removes Google Analytics.