### PR TITLE
Refine the Selected Work card layout

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -425,7 +425,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  padding: $sp-4;
+  padding: $sp-3 $sp-4;
   background: $body-background-color;
   border: $border $border-color;
   border-radius: 8px;
@@ -465,37 +465,58 @@
   margin-top: 0;
   margin-bottom: $sp-2;
   font-size: 1.125rem !important;
+  line-height: 1.35;
 }
 
 .evidence-card-question {
   margin-top: 0;
+  margin-bottom: $sp-3;
   color: $body-heading-color;
+  font-size: 0.9375rem;
   font-weight: 500;
+  line-height: 1.45;
 }
 
-.evidence-card-details {
+.main-content .evidence-card-details {
+  display: grid;
+  grid-template: auto / minmax(0, 1fr);
   margin: 0 0 $sp-3;
 
   div {
-    padding: $sp-2 0;
+    display: grid;
+    grid-template-columns: 4.25rem minmax(0, 1fr);
+    gap: $sp-2;
+    align-items: start;
+    padding: 0.5rem 0;
     border-top: $border $border-color;
   }
 
   dt {
-    margin-bottom: 0.125rem;
+    margin: 0.125rem 0 0;
     font-size: 0.6875rem;
     font-weight: 700;
+    line-height: 1.4;
     letter-spacing: 0.04em;
+    text-align: left;
     text-transform: uppercase;
+
+    &::after {
+      content: none;
+    }
   }
 
   dd {
+    min-width: 0;
     margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    overflow-wrap: break-word;
   }
 }
 
 .evidence-card-link {
   margin-top: auto;
+  font-size: 0.9375rem;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary

- make every Role, Evidence, and Limits row use the full card width
- replace the accidental half-card definition-list layout with a compact label-and-value grid
- remove the inherited definition-list colons and right alignment inside these cards
- tighten vertical padding, typography, and line height without removing any evidence or limitation text
- preserve the existing two-column desktop grid and one-column responsive layout

## Why

The site-wide definition-list styles were also being applied to the Selected Work component. Because each detail group is wrapped in its own `div`, those wrappers became grid cells: Role and Evidence were squeezed into half-width columns, while Limits occupied only the left half of the next row. This caused excessive wrapping, uneven whitespace, and unnecessarily tall cards.

The fix is scoped to the evidence-card component, so normal definition lists elsewhere on the site remain unchanged.

## User impact

Selected Work remains evidence-forward, but the four cards are shorter, easier to scan, and visually consistent. All existing content and links are preserved.

## Validation

- `npm test`
- `git diff --check`
- independent Dart Sass compilation of the complete theme modules and custom stylesheet
- remote Git tree SHA matched the locally validated tree: `10dd83b197b219e9f53d31896c2afba2307a9fa1`

GitHub Actions performs the full Jekyll build, generated HTML/navigation validation, and platform matrix checks.