### PR TITLE
Clarify roles in Selected Work

### DIFF
--- a/_includes/components/evidence_card.html
+++ b/_includes/components/evidence_card.html
@@ -7,7 +7,7 @@
   <p class="evidence-card-question">{{ include.question }}</p>
   <dl class="evidence-card-details">
     <div>
-      <dt>Role</dt>
+      <dt>My Role</dt>
       <dd>{{ include.role }}</dd>
     </div>
     <div>

--- a/index.md
+++ b/index.md
@@ -37,11 +37,11 @@ I am examining what allows learning, performance, identity, or group coordinatio
   url="/research/current-inquiry"
 %}
 {% include components/evidence_card.html
-  type="Project"
+  type="Company"
   status="Active"
   title="K2Quant"
   question="How can quantitative systems, AI-assisted workflows, and a technical organization be built reliably?"
-  role="Founder and software engineer"
+  role="Founder"
   evidence="Operating software, engineering systems, organizational practice, and published architecture essays"
   limits="Confidential operations and future goals are not presented as public evidence"
   url="/projects/k2quant"
@@ -51,7 +51,7 @@ I am examining what allows learning, performance, identity, or group coordinatio
   status="Active"
   title="Vocora"
   question="How should a learning product distinguish activity, current performance, and durable learning?"
-  role="Independent researcher and builder"
+  role="Founder, builder, and independent researcher"
   evidence="Open-source software, product instrumentation, research notes, and planned delayed measures"
   limits="Current product use does not yet demonstrate long-term learning effectiveness"
   url="/projects/vocora"


### PR DESCRIPTION
## What changed

- Renamed the card label from `Role` to `My Role` so it describes Mohammad’s relationship to each body of work rather than its nature.
- Classified K2Quant as a `Company` and stated Mohammad’s role as `Founder`.
- Clarified the Vocora role as `Founder, builder, and independent researcher`.

## Why

K2Quant is an operating company founded as a startup, not a research project. Separating each card’s type from Mohammad’s role prevents the overall `Independent Researcher` title from being incorrectly applied to every body of work.

## Validation

- `npm test`
- Content architecture: 179 source pages and 179 unique routes
- Site integrity, internal links, language metadata, CSS, and formatting all pass
- Remote blob and tree SHAs match the locally tested commit