### PR TITLE
Add a research note on learning after courses end

### DIFF
--- a/docs/research/field-notes/what-remains-when-the-course-ends.md
+++ b/docs/research/field-notes/what-remains-when-the-course-ends.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: "What Remains When the Course Ends?"
+description: "A ten-day field note on how leadership learning appeared to persist—or fade—after participants returned to changing work and life contexts."
+parent: Research Notes
+direction: ltr
+lang: en
+locale: en_US
+author: Mohammad Bayat
+date: 2026-07-23
+date_modified: 2026-07-23
+last_modified_date: 2026-07-23
+status: working-note
+program: human-transformation
+note_type: field-note
+evidence_level: informal-follow-up-conversations-and-facilitator-interpretation
+privacy: anonymized-aggregate
+seo:
+  type: Article
+categories:
+  - research
+  - field-notes
+tags:
+  - leadership-education
+  - learning-transfer
+  - context
+  - whole-person-learning
+  - reflective-practice
+  - human-transformation
+sitemap: true
+permalink: /research/field-notes/what-remains-when-the-course-ends
+---
+
+# What Remains When the Course Ends?
+{: .no_toc }
+
+{ A ten-day field note on leadership learning, context, and transfer | fs-6 }
+
+{: .note-title }
+> About this note
+>
+> This is a field note, not a scientific paper or evidence that one program caused lasting transformation. It is based on informal follow-up conversations with people I already knew, my notes as a facilitator, and my interpretation of recurring patterns. Details are kept at an aggregate level.
+
+A learning environment can make reflection, openness, and action more available. But what happens when that environment disappears? This question became difficult to ignore after I watched people act differently inside a carefully supported organizational setting, then sometimes return to earlier patterns after moving into another team or company.
+
+Over the past ten days, I followed this question through a set of friendly, semi-structured conversations with former participants in leadership programs. The conversations did not give me an answer. They gave me a sharper question:
+
+> **What must change in a person—or in the relationship between a person and context—for learning to remain available across different environments?**
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+## Where the question began
+
+Earlier, during six months of work inside an organization, I helped create a setting where people could speak more openly, reflect together, and act with greater responsibility. Within that setting, many people appeared to work differently.
+
+The difficulty appeared when the setting changed. Some people who had shown openness and initiative in one group seemed to lose access to those capacities in another group with different histories, expectations, power relationships, and ways of listening. It sometimes looked like a reset.
+
+This observation also connects with a longer inquiry I developed in [Holistic Learning: From Knowing to Dwelling](/writing/reading-notes/holistic-learning) (in Persian): learning may be deeper than acquiring information, but its real test is whether it becomes available in changing life contexts.
+
+This was not a formal experiment. It was a practical observation, and it left me asking whether we were helping people perform well inside a particular container—or helping them develop a way of being and learning that could travel with them.
+
+## What I did over ten days
+
+During the last ten days, I contacted a number of former participants whom I knew personally. Most conversations lasted about 60 to 90 minutes. They knew I was asking about the programs, but the conversations were friendly and open rather than questionnaire-driven. I kept several themes in mind and took notes.
+
+I asked how their work and projects were going; what obstacles, failures, conflicts, and family tensions they had faced; how they responded during periods of conflict, social unrest, and internet disruption; whether they continued working after setbacks; and where, if anywhere, they still used distinctions from leadership education.
+
+I also listened for something participants often said without being asked directly: whether they wanted another course. That comment became important because it sometimes revealed where they believed their ability to act was located—in themselves, or in the course environment.
+
+## A pattern I noticed
+
+The people did not divide into two perfect types. Some were doing well professionally and some were not. Some had faced major setbacks. No group behaved uniformly.
+
+Still, a pattern appeared.
+
+Among participants who had attended leadership courses but not **Mastery for Life**, several described the course itself as a period when they were more focused, active, and connected to their projects. Some said they wanted another course because they functioned better while they were inside one. My impression was that parts of the learning had remained attached to the learning environment. As that environment disappeared, older habits gradually became more influential again.
+
+Among participants who had also completed **Mastery for Life**, I more often heard accounts of applying the learning across work, family relationships, projects, and setbacks. Some described calmer decision-making. Some continued after a business or project failure without treating the failure as a final verdict on themselves. During disruption, they appeared more likely to ask what path remained available rather than only describe why action had become impossible.
+
+This was not simply a difference between “successful” and “unsuccessful” people. Some who had completed Mastery for Life were not especially successful by conventional measures. What seemed different was their relationship to difficulty: breakdowns more often became situations to work with, rather than conditions that automatically returned them to an earlier pattern.
+
+## My current interpretation
+
+My tentative interpretation is that some learning remains dependent on the social container that made it possible. A supportive cohort can change what people say, notice, and attempt. But when a person enters a different context, old roles, histories, fears, and expectations can become active again.
+
+A more durable change may involve more than remembering concepts or repeating techniques. It may involve a change in how a person meets uncertainty, failure, conflict, and not knowing. In that case, the learning is not a response that only works in one room. It becomes a capacity to observe the new context, notice one’s own reaction, and choose again.
+
+This does not mean a person becomes independent of context. No one does. It means the person may become less automatically governed by each new context and more able to participate in shaping it.
+
+## What this note cannot claim
+
+This observation has serious limits. The people were not randomly selected. I knew them personally and had also facilitated their programs. Participation in Mastery for Life was self-selected. The conversations were not based on one standardized interview guide, and I did not use independent interviewers, validated measures, baseline data, matched groups, or formal coding. The accounts were retrospective and may be affected by memory, loyalty, current circumstances, and my expectations.
+
+For those reasons, I cannot claim that Mastery for Life caused the differences I noticed. Other explanations are possible: people who chose the program may already have differed in motivation, support, resources, personality, or life circumstances.
+
+The value of these conversations is not proof. It is that they made a pattern visible enough to investigate properly.
+
+## The question ahead
+
+The question I now want to pursue is:
+
+> **How can leadership education support learning that remains usable when the learner leaves the course, enters a less supportive environment, faces disruption, or joins a group organized by very different norms?**
+
+A stronger study would follow participants over time, define observable outcomes in advance, compare different learning designs more carefully, include unsuccessful and neutral cases, and examine both the person and the new environment.
+
+For now, this note marks the beginning of that inquiry. The important question is no longer only whether people change during a course. It is what remains when the course is over.

--- a/docs/research/field-notes/what-remains-when-the-course-ends.md
+++ b/docs/research/field-notes/what-remains-when-the-course-ends.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "What Remains When the Course Ends?"
-description: "A ten-day field note on how leadership learning appeared to persist—or fade—after participants returned to changing work and life contexts."
+description: "A ten-day exploratory note on how leadership learning appeared to persist—or fade—after participants returned to changing work and life contexts."
 parent: Research Notes
 direction: ltr
 lang: en
@@ -28,18 +28,18 @@ tags:
   - reflective-practice
   - human-transformation
 sitemap: true
-permalink: /research/field-notes/what-remains-when-the-course-ends
+permalink: /research/notes/what-remains-when-the-course-ends
 ---
 
 # What Remains When the Course Ends?
 {: .no_toc }
 
-{ A ten-day field note on leadership learning, context, and transfer | fs-6 }
+{ A ten-day exploratory note on leadership learning, context, and transfer | fs-6 }
 
 {: .note-title }
 > About this note
 >
-> This is a field note, not a scientific paper or evidence that one program caused lasting transformation. It is based on informal follow-up conversations with people I already knew, my notes as a facilitator, and my interpretation of recurring patterns. Details are kept at an aggregate level.
+> This is an exploratory research note based on field observations, not a scientific paper or evidence that one program caused lasting transformation. It draws on informal follow-up conversations with people I already knew, my notes as a facilitator, and my interpretation of recurring patterns. Details are kept at an aggregate level.
 
 A learning environment can make reflection, openness, and action more available. But what happens when that environment disappears? This question became difficult to ignore after I watched people act differently inside a carefully supported organizational setting, then sometimes return to earlier patterns after moving into another team or company.
 

--- a/docs/research/notes/index.md
+++ b/docs/research/notes/index.md
@@ -39,7 +39,7 @@ These notes are also collected in [Research Publications](/research/publications
 
 ## Field Notes
 
-{% assign field_notes = site.pages | where: "note_type", "field-note" | sort: "date" | reverse %}
+{% assign field_notes = site.pages | where_exp: "note", "note.categories contains 'field-notes'" | sort: "date" | reverse %}
 {% for note in field_notes %}
 - [{{ note.title }}]({{ note.url }}) — {{ note.description }}
 {% endfor %}

--- a/docs/research/notes/index.md
+++ b/docs/research/notes/index.md
@@ -37,6 +37,13 @@ These notes are also discoverable in [All Writing](/writing/all) and, when conne
 
 These notes are also collected in [Research Publications](/research/publications).
 
+## Field Notes
+
+{% assign field_notes = site.pages | where: "note_type", "field-note" | sort: "date" | reverse %}
+{% for note in field_notes %}
+- [{{ note.title }}]({{ note.url }}) — {{ note.description }}
+{% endfor %}
+
 ## Common Note Types
 
 ### Open Question

--- a/docs/research/notes/index.md
+++ b/docs/research/notes/index.md
@@ -35,14 +35,9 @@ These notes are also discoverable in [All Writing](/writing/all) and, when conne
 {% endif %}
 {% endfor %}
 
+- [What Remains When the Course Ends?](/research/notes/what-remains-when-the-course-ends) — A ten-day exploratory observation on whether leadership learning remains available across changing work and life contexts.
+
 These notes are also collected in [Research Publications](/research/publications).
-
-## Field Notes
-
-{% assign field_notes = site.pages | where_exp: "note", "note.categories contains 'field-notes'" | sort: "date" | reverse %}
-{% for note in field_notes %}
-- [{{ note.title }}]({{ note.url }}) — {{ note.description }}
-{% endfor %}
 
 ## Common Note Types
 


### PR DESCRIPTION
## What changed

- add the English note **What Remains When the Course Ends?**
- keep it inside the existing **Research Notes → Human Learning, Leadership & Transformation** grouping
- use the existing `/research/notes/...` URL structure rather than introducing a new visible Field Notes section
- present the ten-day follow-up conversations as an exploratory observation rather than a scientific or causal claim
- distinguish participant self-report, facilitator interpretation, alternative explanations, and methodological limits
- link internally to the existing Persian holistic-learning article

## Why

The note records a developing research question: why some leadership learning appears to remain tied to a supportive course environment, while some participants appear better able to use it across changing work, family, project, and crisis contexts.

## Evidence and privacy boundaries

- participants remain anonymous and are discussed only in aggregate
- no direct quotations or identifying case details are included
- the note explicitly states that the conversations were informal, non-random, retrospective, and conducted by the program facilitator
- it does not claim that Mastery for Life caused the observed differences

## Information architecture

The Git branch is temporary and exists only for review. It does not create a site menu. The article is placed under the existing Research Notes hierarchy, and no separate Field Notes menu or index section is introduced.

## Validation

- the visible diff is limited to the new note and a single link in the existing Research Notes index
- required article metadata, one generated table of contents, a canonical permalink, and an internal-only link were checked
- full Jekyll, navigation, and site-integrity validation is left to GitHub Actions
