### PR TITLE
Fix bilingual child-page tables of contents

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -5,7 +5,10 @@
   Includes: components/nav/sorted.html, toc_heading_custom.html.
   Overwrites:
     nav_ancestor_links, nav_top_node_titles, nav_child_candidates, nav_children,
-    nav_child, nav_child_ok, nav_child_ancestor, nav_sorted.
+    nav_child, nav_child_ok, nav_child_ancestor, nav_sorted,
+    nav_page_pool, nav_child_path, nav_child_suffix, nav_counterpart_path,
+    nav_en_child, nav_fa_child, nav_hide_child, nav_alternate_child,
+    nav_alternate_code, nav_alternate_label, nav_alternate_name.
 {%- endcomment -%}
 
 {%- comment -%}
@@ -41,9 +44,9 @@
         | split: nav_list_link | last
         | split: "</a>" | slice: 1 | first -%}
 
-  {%- assign nav_child_test = nav_child_start 
+  {%- assign nav_child_test = nav_child_start
         | remove_first: nav_list_simple | prepend: nav_list_simple -%}
-    
+
   {%- if nav_child_start != nav_child_test -%}
     {%- assign nav_children = "" | split: "" -%}
   {%- endif -%}
@@ -63,7 +66,8 @@
     {%- assign nav_ancestors = nav_ancestors | push: nav_title -%}
   {%- endfor -%}
 
-  {%- assign nav_parenthood = site[page.collection] | default: site.html_pages
+  {%- assign nav_page_pool = site[page.collection] | default: site.html_pages -%}
+  {%- assign nav_parenthood = nav_page_pool
     | where_exp: "item", "item.title != nil" | group_by: "parent" -%}
 
   {%- assign nav_top_nodes = nav_parenthood
@@ -89,9 +93,49 @@
 {%- endif -%}
 <ul>
   {% for nav_child in nav_children %}
+    {%- assign nav_child_path = nav_child.path | default: "" -%}
+    {%- assign nav_child_suffix = nav_child_path | slice: -6, 6 -%}
+    {%- assign nav_en_child = nil -%}
+    {%- assign nav_fa_child = nil -%}
+    {%- assign nav_hide_child = false -%}
+    {%- assign nav_alternate_child = nil -%}
+    {%- assign nav_alternate_code = nil -%}
+    {%- assign nav_alternate_label = nil -%}
+    {%- assign nav_alternate_name = nil -%}
+
+    {%- if nav_child_suffix == "-en.md" -%}
+      {%- assign nav_counterpart_path = nav_child_path | replace: "-en.md", "-fa.md" -%}
+      {%- assign nav_fa_child = nav_children | where: "path", nav_counterpart_path | first -%}
+      {%- if nav_fa_child -%}
+        {%- if page.lang == "fa" -%}
+          {%- assign nav_hide_child = true -%}
+        {%- else -%}
+          {%- assign nav_alternate_child = nav_fa_child -%}
+          {%- assign nav_alternate_code = "fa" -%}
+          {%- assign nav_alternate_label = "FA" -%}
+          {%- assign nav_alternate_name = "Persian" -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- elsif nav_child_suffix == "-fa.md" -%}
+      {%- assign nav_counterpart_path = nav_child_path | replace: "-fa.md", "-en.md" -%}
+      {%- assign nav_en_child = nav_children | where: "path", nav_counterpart_path | first -%}
+      {%- if nav_en_child -%}
+        {%- if page.lang == "fa" -%}
+          {%- assign nav_alternate_child = nav_en_child -%}
+          {%- assign nav_alternate_code = "en" -%}
+          {%- assign nav_alternate_label = "EN" -%}
+          {%- assign nav_alternate_name = "English" -%}
+        {%- else -%}
+          {%- assign nav_hide_child = true -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endif -%}
+
+    {%- unless nav_hide_child -%}
   <li>
-    <a href="{{ nav_child.url | relative_url }}">{{ nav_child.title }}</a>{% if nav_child.summary %} - <small>{{ nav_child.summary }}</small>{% endif %}
+    <a href="{{ nav_child.url | relative_url }}">{{ nav_child.title }}</a>{% if nav_alternate_child %} <span class="child-nav-language-link" dir="ltr">(<a href="{{ nav_alternate_child.url | relative_url }}" lang="{{ nav_alternate_code }}" hreflang="{{ nav_alternate_code }}" aria-label="Open the {{ nav_alternate_name }} version of {{ nav_child.title | escape }}" title="{{ nav_alternate_name }} version">{{ nav_alternate_label }}</a>)</span>{% endif %}{% if nav_child.summary %} - <small>{{ nav_child.summary }}</small>{% endif %}
   </li>
+    {%- endunless -%}
   {% endfor %}
 </ul>
 

--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -93,6 +93,11 @@
 {%- endif -%}
 <ul>
   {% for nav_child in nav_children %}
+    {%- comment -%}
+      Pair only exact sibling source stems such as `entry-en.md` and `entry-fa.md`.
+      The current page language selects the primary title; the other edition is
+      retained as the compact language link.
+    {%- endcomment -%}
     {%- assign nav_child_path = nav_child.path | default: "" -%}
     {%- assign nav_child_suffix = nav_child_path | slice: -6, 6 -%}
     {%- assign nav_en_child = nil -%}

--- a/scripts/validate_child_page_navigation.rb
+++ b/scripts/validate_child_page_navigation.rb
@@ -18,58 +18,105 @@ def generated_page_path(site_dir, url)
 end
 
 
-def contains_href?(html, url)
+def href_variants(url)
   normalized = url.to_s.sub(%r{/\z}, "")
-  variants = [normalized, "#{normalized}/"].uniq
+  [normalized, "#{normalized}/"].uniq
+end
 
-  variants.any? do |href|
+
+def contains_href?(html, url)
+  href_variants(url).any? do |href|
     html.match?(/href=["']#{Regexp.escape(href)}["']/)
   end
 end
 
-parent_url = "/writing"
-expected_children = %w[
+
+def child_list_for(site_dir, parent_url, heading: "Table of contents")
+  page_path = generated_page_path(site_dir, parent_url)
+
+  unless page_path
+    warn "Generated parent page is missing: #{parent_url}"
+    exit 1
+  end
+
+  html = page_path.read(encoding: "UTF-8")
+  main_match = html.match(/<main\b[^>]*>(.*?)<\/main>/mi)
+
+  unless main_match
+    warn "Generated parent page does not contain a main element: #{page_path}"
+    exit 1
+  end
+
+  toc_match = main_match[1].match(
+    /<h2\b[^>]*class=["'][^"']*\btext-delta\b[^"']*["'][^>]*>\s*#{Regexp.escape(heading)}\s*<\/h2>\s*<ul>(.*?)<\/ul>/mi
+  )
+
+  unless toc_match
+    warn "Automatic child-page table of contents is missing from #{parent_url}"
+    exit 1
+  end
+
+  toc_match[1]
+end
+
+
+def child_item_for(child_list_html, url)
+  child_list_html.split(/<li\b[^>]*>/mi).drop(1).find do |item_html|
+    contains_href?(item_html, url)
+  end
+end
+
+
+writing_url = "/writing"
+writing_children = %w[
   /writing/essays
   /writing/reading-notes
   /writing/translations
   /writing/podcast
   /writing/all
 ]
+writing_list_html = child_list_for(SITE_DIR, writing_url)
+missing_writing_children = writing_children.reject do |child_url|
+  contains_href?(writing_list_html, child_url)
+end
 
-page_path = generated_page_path(SITE_DIR, parent_url)
-
-unless page_path
-  warn "Generated parent page is missing: #{parent_url}"
+unless missing_writing_children.empty?
+  warn "Automatic child-page table of contents is incomplete for #{writing_url}:"
+  missing_writing_children.each { |child_url| warn "- missing child link: #{child_url}" }
   exit 1
 end
 
-html = page_path.read(encoding: "UTF-8")
-main_match = html.match(/<main\b[^>]*>(.*?)<\/main>/mi)
+contact_url = "/contact"
+contact_list_html = child_list_for(SITE_DIR, contact_url)
+calendar_item_html = child_item_for(contact_list_html, "/contact/calendar")
 
-unless main_match
-  warn "Generated parent page does not contain a main element: #{page_path}"
+unless calendar_item_html
+  warn "Contact child navigation is missing the English Schedule a Meeting link"
   exit 1
 end
 
-main_html = main_match[1]
-toc_match = main_html.match(
-  /<h2\b[^>]*class=["'][^"']*\btext-delta\b[^"']*["'][^>]*>\s*Table of contents\s*<\/h2>\s*<ul>(.*?)<\/ul>/mi
+unless calendar_item_html.include?("Schedule a Meeting")
+  warn "Contact child navigation does not use the English child title"
+  exit 1
+end
+
+unless contains_href?(calendar_item_html, "/contact/calendar-fa")
+  warn "Contact child navigation is missing the paired Persian link"
+  exit 1
+end
+
+unless calendar_item_html.match?(
+  /\(\s*<a\b[^>]*href=["']\/contact\/calendar-fa\/?["'][^>]*>\s*FA\s*<\/a>\s*\)/mi
 )
-
-unless toc_match
-  warn "Automatic child-page table of contents is missing from #{parent_url}"
+  warn "Contact child navigation must render the Persian counterpart as (FA)"
   exit 1
 end
 
-child_list_html = toc_match[1]
-missing_children = expected_children.reject do |child_url|
-  contains_href?(child_list_html, child_url)
-end
-
-unless missing_children.empty?
-  warn "Automatic child-page table of contents is incomplete for #{parent_url}:"
-  missing_children.each { |child_url| warn "- missing child link: #{child_url}" }
+if contact_list_html.include?("تنظیم جلسه")
+  warn "Contact child navigation renders the Persian child as a duplicate list item"
   exit 1
 end
 
-puts "Child-page navigation validation passed: #{parent_url} lists #{expected_children.length} direct children"
+puts "Child-page navigation validation passed:"
+puts "- #{writing_url} lists #{writing_children.length} direct children"
+puts "- #{contact_url} renders one bilingual child row with an (FA) counterpart"


### PR DESCRIPTION
## Summary

- collapse paired `-en.md` / `-fa.md` child pages into one table-of-contents row
- show the English child title with an `(FA)` counterpart link on English parent pages
- show the Persian child title with an `(EN)` counterpart link on Persian parent pages
- keep single-language child pages unchanged
- preserve the existing child ordering and summaries

## Validation

- extended the generated-site child-navigation check to cover the bilingual Contact calendar pair
- verify the English title and `(FA)` link render in one list item
- verify the Persian title is not emitted as a duplicate list item
- `ruby -c scripts/validate_child_page_navigation.rb`

The full Jekyll build and generated HTML validation run in GitHub Actions.