### PR TITLE
Use full language names in child navigation

### DIFF
--- a/_includes/components/children_nav.html
+++ b/_includes/components/children_nav.html
@@ -8,7 +8,8 @@
     nav_child, nav_child_ok, nav_child_ancestor, nav_sorted,
     nav_page_pool, nav_child_path, nav_child_suffix, nav_counterpart_path,
     nav_en_child, nav_fa_child, nav_hide_child, nav_alternate_child,
-    nav_alternate_code, nav_alternate_label, nav_alternate_name.
+    nav_alternate_code, nav_alternate_label, nav_alternate_name,
+    nav_alternate_direction.
 {%- endcomment -%}
 
 {%- comment -%}
@@ -107,6 +108,7 @@
     {%- assign nav_alternate_code = nil -%}
     {%- assign nav_alternate_label = nil -%}
     {%- assign nav_alternate_name = nil -%}
+    {%- assign nav_alternate_direction = nil -%}
 
     {%- if nav_child_suffix == "-en.md" -%}
       {%- assign nav_counterpart_path = nav_child_path | replace: "-en.md", "-fa.md" -%}
@@ -117,8 +119,9 @@
         {%- else -%}
           {%- assign nav_alternate_child = nav_fa_child -%}
           {%- assign nav_alternate_code = "fa" -%}
-          {%- assign nav_alternate_label = "FA" -%}
+          {%- assign nav_alternate_label = "نسخه‌ی فارسی" -%}
           {%- assign nav_alternate_name = "Persian" -%}
+          {%- assign nav_alternate_direction = "rtl" -%}
         {%- endif -%}
       {%- endif -%}
     {%- elsif nav_child_suffix == "-fa.md" -%}
@@ -128,8 +131,9 @@
         {%- if page.lang == "fa" -%}
           {%- assign nav_alternate_child = nav_en_child -%}
           {%- assign nav_alternate_code = "en" -%}
-          {%- assign nav_alternate_label = "EN" -%}
+          {%- assign nav_alternate_label = "English Version" -%}
           {%- assign nav_alternate_name = "English" -%}
+          {%- assign nav_alternate_direction = "ltr" -%}
         {%- else -%}
           {%- assign nav_hide_child = true -%}
         {%- endif -%}
@@ -138,7 +142,7 @@
 
     {%- unless nav_hide_child -%}
   <li>
-    <a href="{{ nav_child.url | relative_url }}">{{ nav_child.title }}</a>{% if nav_alternate_child %} <span class="child-nav-language-link" dir="ltr">(<a href="{{ nav_alternate_child.url | relative_url }}" lang="{{ nav_alternate_code }}" hreflang="{{ nav_alternate_code }}" aria-label="Open the {{ nav_alternate_name }} version of {{ nav_child.title | escape }}" title="{{ nav_alternate_name }} version">{{ nav_alternate_label }}</a>)</span>{% endif %}{% if nav_child.summary %} - <small>{{ nav_child.summary }}</small>{% endif %}
+    <a href="{{ nav_child.url | relative_url }}">{{ nav_child.title }}</a>{% if nav_alternate_child %} <span class="child-nav-language-link" dir="ltr">(<a href="{{ nav_alternate_child.url | relative_url }}" lang="{{ nav_alternate_code }}" hreflang="{{ nav_alternate_code }}" dir="{{ nav_alternate_direction }}" aria-label="Open the {{ nav_alternate_name }} version of {{ nav_child.title | escape }}" title="{{ nav_alternate_name }} version">{{ nav_alternate_label }}</a>)</span>{% endif %}{% if nav_child.summary %} - <small>{{ nav_child.summary }}</small>{% endif %}
   </li>
     {%- endunless -%}
   {% endfor %}

--- a/scripts/validate_child_page_navigation.rb
+++ b/scripts/validate_child_page_navigation.rb
@@ -106,9 +106,9 @@ unless contains_href?(calendar_item_html, "/contact/calendar-fa")
 end
 
 unless calendar_item_html.match?(
-  /\(\s*<a\b[^>]*href=["']\/contact\/calendar-fa\/?["'][^>]*>\s*FA\s*<\/a>\s*\)/mi
+  /\(\s*<a\b[^>]*href=["']\/contact\/calendar-fa\/?["'][^>]*>\s*نسخه‌ی فارسی\s*<\/a>\s*\)/mi
 )
-  warn "Contact child navigation must render the Persian counterpart as (FA)"
+  warn "Contact child navigation must render the Persian counterpart as (نسخه‌ی فارسی)"
   exit 1
 end
 
@@ -117,6 +117,14 @@ if contact_list_html.include?("تنظیم جلسه")
   exit 1
 end
 
+template_source = ROOT.join("_includes/components/children_nav.html").read(encoding: "UTF-8")
+
+unless template_source.include?('nav_alternate_label = "English Version"')
+  warn "Persian child navigation must label the English counterpart as (English Version)"
+  exit 1
+end
+
 puts "Child-page navigation validation passed:"
 puts "- #{writing_url} lists #{writing_children.length} direct children"
-puts "- #{contact_url} renders one bilingual child row with an (FA) counterpart"
+puts "- #{contact_url} renders one bilingual child row with a (نسخه‌ی فارسی) counterpart"
+puts "- Persian parent pages use (English Version) for paired English children"


### PR DESCRIPTION
## Summary

- replace `(FA)` with `(نسخه‌ی فارسی)` on English parent pages
- replace `(EN)` with `(English Version)` on Persian parent pages
- keep the counterpart labels directionally isolated so mixed Persian/English text and parentheses render correctly
- update the child-navigation regression check for the new labels

## Scope

This follow-up uses the same `fix/language-aware-child-toc` branch name. The previous PR from that branch was already merged and GitHub deleted the branch, so the branch was recreated from current `main` for this focused change.

## Validation

- branch is based on current `main`
- diff is limited to the child-navigation include and its regression check
- full Jekyll and generated HTML validation will run in GitHub Actions