### PR TITLE
Add a research note on carrying learning across contexts

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -178,6 +178,23 @@ works:
         title: "Can Awareness Initiate Transformation? Four Field Observations from Learning, Leadership, and Coaching"
         url: /research/notes/awareness-transformative-learning-en
 
+  - id: can-the-learner-carry-the-context
+    content_type: research-note
+    primary_body: human-transformation
+    bodies_of_work:
+      - human-transformation
+    themes:
+      - learning-memory-language
+      - leadership-identity-coordination
+      - philosophy-worldview
+    program: human-transformation
+    summary: A source-based inquiry into reflective practice, double-loop learning, coaching, and the capacity to continue learning across changing contexts.
+    editions:
+      - lang: en
+        label: English
+        title: "Can the Learner Carry the Context?"
+        url: /research/notes/can-the-learner-carry-the-context
+
   - id: vocora-learning-metrics
     content_type: research-note
     primary_body: building

--- a/docs/research/notes/can-the-learner-carry-the-context.md
+++ b/docs/research/notes/can-the-learner-carry-the-context.md
@@ -1,0 +1,168 @@
+---
+layout: default
+title: "Can the Learner Carry the Context?"
+description: "A research note on reflective practice, double-loop learning, coaching, and the deeper question of what allows learning to remain available after the classroom disappears."
+parent: Research Notes
+direction: ltr
+lang: en
+locale: en_US
+author: Mohammad Bayat
+date: 2026-07-23
+date_modified: 2026-07-23
+last_modified_date: 2026-07-23
+status: working-note
+program: human-transformation
+note_type: reading-and-inquiry-note
+evidence_level: published-qualitative-study-and-practice-based-interpretation
+privacy: no-client-cases-or-identifying-details
+seo:
+  type: Article
+categories:
+  - research
+  - research-notes
+tags:
+  - learning-transfer
+  - reflective-practice
+  - double-loop-learning
+  - coaching
+  - context
+  - human-transformation
+sitemap: true
+permalink: /research/notes/can-the-learner-carry-the-context
+---
+
+# Can the Learner Carry the Context?
+{: .no_toc }
+
+{ Reflective practice, double-loop learning, and what must remain after the classroom disappears | fs-6 }
+
+{: .note-title }
+> About this note
+>
+> This is a reading and inquiry note, not a literature review or a claim that one coaching framework explains how learning transfer works. It combines my reading of one qualitative study with a distinction from my coaching practice. The purpose is to clarify an existing research question and identify what I still need to investigate.
+
+The question came first.
+
+Before I encountered the paper discussed here, I was already asking what allows learning to remain available after a class, a leadership program, or a carefully facilitated group has ended. I did not read the paper and then discover this question. I found the paper because I was already following it.
+
+In June 2026, that search led me to Griggs, Holden, Lawless, and Rae's study, [*From Reflective Learning to Reflective Practice: Assessing Transfer*](https://eprints.whiterose.ac.uk/id/eprint/104326/3/GriggsFrom%20reflective%20learning%20to%20reflective%20practice%3B%20assessing%20.pdf). Reading it did not replace my question with a new one. It gave the question a clearer intellectual location, stronger language, and greater urgency.
+
+This note continues the inquiry I documented in [What Remains When the Course Ends?](/research/notes/what-remains-when-the-course-ends). There, I approached the question through exploratory conversations and field observations. Here, I approach it through a published study, double-loop learning, and a distinction I have encountered in coaching.
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+## What the paper examined
+
+The study asked whether reflective learning taught in higher education later becomes reflective practice at work. The researchers interviewed eighteen human resources professionals who had completed professional programs between six months and three years earlier.
+
+Their finding was neither that classroom learning simply transfers nor that it disappears. The transfer was uneven. Formal techniques such as written models and learning logs were rarely reproduced in the workplace exactly as they had been taught. Yet some participants appeared to have developed a more questioning way of thinking: they considered other perspectives, examined their own reactions, and became less likely to accept situations at face value.
+
+The paper identifies three interacting influences on whether reflective practice continues:
+
+- the context of work;
+- the processes that prompt or support reflection; and
+- the readiness and transformation of the learner.
+
+This matters because it moves the question beyond memory. A learner may stop using the visible technique while still carrying something more important from it. The paper's conclusion leaves open the possibility that the deeper result is not direct transfer of a method, but transformation of the learner.
+
+The study does not establish that the course caused this transformation. Its sample was small and self-selecting, the evidence came from retrospective self-report, and former tutors participated in the interviews. I read it as grounded evidence that transfer is uneven and complex—not as proof of one mechanism or educational design.
+
+That possibility, held together with those limits, is central to my question.
+
+## The double-loop distinction
+
+One part of the paper briefly identifies an example of double-loop learning. That reference brought back a distinction that has stayed with me.
+
+A simple illustration is a cold room. A single-loop response raises the heater. It corrects the immediate condition while leaving the governing situation unchanged. A double-loop inquiry asks why the room keeps becoming cold: Is a window open? Why is it open? What assumptions or decisions keep producing the same problem?
+
+Single-loop learning asks how to perform an action more effectively. Double-loop learning also examines the assumptions, goals, and patterns that make that action seem necessary.
+
+Both forms matter. Immediate problems need to be addressed. But when learning remains only at the level of correction, the person may become better at repeatedly solving a problem without becoming more able to see what keeps generating it.
+
+This changes how I understand learning after a course. The weakest version of transfer asks whether a participant remembers and applies a technique. A stronger version asks whether the participant can question the frame through which a new situation is understood.
+
+## What coaching helped me notice
+
+A distinction from my coaching experience helped me see the same issue from another direction. In one coaching framework I have worked with, I can describe three levels of attention.
+
+At the first level, the client brings a problem and the coaching conversation helps them address that problem. The value is real, but it can remain local to the presenting issue.
+
+At the second level, the conversation also asks what the client learned about themselves and what they may be able to use in similar situations. The result can travel further. The client is not only better equipped for one problem; they may be better equipped for a family of related problems.
+
+At the third level, attention moves from the isolated problem toward the person and the recurring pattern: Why does this kind of problem repeatedly become possible for this person? What assumptions, commitments, interpretations, or ways of relating to the world help produce it? The immediate issue may still be addressed, but the inquiry reaches beneath it.
+
+I do not treat these coaching levels as a scientific model of learning transfer, and I do not assume they map perfectly onto single-loop and double-loop learning. The connection is conceptual. Both distinctions show that there is a difference between correcting an event, learning a reusable response, and transforming the way a person perceives and participates in situations.
+
+That distinction makes my original question more demanding.
+
+## The limits of a supportive context
+
+The paper rightly shows that workplace context matters. Time pressure, organizational culture, managers, colleagues, and opportunities for dialogue can either support or restrict reflective practice. A person does not learn in isolation from these conditions.
+
+But for me, that finding does not close the inquiry. It intensifies it.
+
+What happens when the supportive manager changes? What happens when the learner joins another company, the team grows, financial pressure increases, or a crisis reorganizes everyone's attention? What happens when the environment no longer provides the prompts, relationships, or psychological space that made reflection possible?
+
+These are not unusual exceptions to learning transfer. They are the conditions under which transfer is tested.
+
+A course cannot prepare one fixed external context for every future situation. The learner will eventually enter settings that were not designed to protect the learning. If the capacity exists only while the original container remains intact, then the learning may be effective but still context-bound.
+
+The question is therefore not how to make a person independent of context. That would be neither possible nor desirable. Human beings are always shaped by relationships, histories, institutions, and material conditions.
+
+The deeper question is whether learning can change a person's relationship with context.
+
+Can the learner become more able to notice the forces acting on them, question the assumptions becoming active, seek or create reflective relationships, and participate in shaping the new environment? Can the learner carry not a copy of the classroom, but the capacity to reconstruct some of the conditions that made inquiry possible?
+
+## From portable techniques to a portable capacity
+
+This distinction suggests two very different ambitions for education.
+
+The first is to make a technique portable. The learner leaves with a model, a checklist, a journal format, or a sequence of questions. These can be useful. They give reflection a structure and can provide an entry point when experience is confusing.
+
+The second is to develop a portable capacity. The learner becomes more able to pause, observe, examine assumptions, include other perspectives, recognize recurring patterns, and choose a response instead of automatically repeating one.
+
+The paper gives some evidence that this second outcome may occur even when the formal technique is no longer visible. Some participants did not reproduce the classroom process, but their way of seeing and questioning appeared to have changed.
+
+This is why the paper strengthened my original inquiry. It gave me evidence that the important outcome may be less visible than the transfer of a method. It also showed why the outcome is difficult to evaluate: a transformed way of relating to experience may not appear as faithful use of a classroom tool.
+
+That creates a design and research problem. If we evaluate only whether participants remember content or perform a technique, we may miss deeper change. But if we speak vaguely about transformation without defining observable evidence, we may claim more than we know.
+
+## The question I am following
+
+The question I am pursuing is not simply:
+
+> How can people remember and use what they learned after a course?
+
+It is:
+
+> **How can education help develop a learner whose capacity for inquiry, reflection, and choice remains available across changing contexts—and who can help create the conditions for learning when those conditions are no longer provided?**
+
+This question existed before I read the paper. The paper gave it greater weight because it showed both sides of the problem: the real influence of the environment and the possibility that something more fundamental can change in the learner.
+
+It also made a weaker answer less satisfying. It is not enough to say that transfer improves when the workplace is supportive. Of course it does. I want to understand what educational experiences help people remain capable of learning when support is incomplete, when familiar structures disappear, and when the new environment activates older patterns.
+
+## What I still need to investigate
+
+This note does not answer that question. It identifies several directions that now seem important:
+
+- how to distinguish technique retention from transformation of the learner;
+- how single-loop and double-loop learning appear in real behavior over time;
+- which course designs help learners notice and work with changing contexts;
+- whether coaching, peer relationships, reflective writing, and communities of practice become internalized capacities or remain external supports;
+- how to observe durable learning without reducing it to self-report or immediate performance; and
+- how learners influence the contexts they enter, rather than being treated only as recipients of environmental conditions.
+
+The study by Griggs and colleagues did not give me a final answer. Its value was different. It showed that the question I had already been following is present in the evidence, that its difficulty is real, and that the most important form of transfer may not be the movement of a technique from one place to another.
+
+It may be the development of a person who can continue to learn when the place changes.
+
+## Reference
+
+Griggs, V., Holden, R. J., Lawless, A., & Rae, J. (2018). [*From Reflective Learning to Reflective Practice: Assessing Transfer*](https://doi.org/10.1080/03075079.2016.1232382). *Studies in Higher Education, 43*(7), 1172–1183.

--- a/docs/research/notes/index.md
+++ b/docs/research/notes/index.md
@@ -35,6 +35,7 @@ These notes are also discoverable in [All Writing](/writing/all) and, when conne
 {% endif %}
 {% endfor %}
 
+- [Can the Learner Carry the Context?](/research/notes/can-the-learner-carry-the-context) — A reading and inquiry note on reflective practice, double-loop learning, coaching, and learning that remains available across changing contexts.
 - [What Remains When the Course Ends?](/research/notes/what-remains-when-the-course-ends) — A ten-day exploratory observation on whether leadership learning remains available across changing work and life contexts.
 
 These notes are also collected in [Research Publications](/research/publications).


### PR DESCRIPTION
## What changed

- add the English research note **Can the Learner Carry the Context?** under the existing **Research Notes → Human Learning, Leadership & Transformation** section
- connect the note to the existing inquiry in **What Remains When the Course Ends?**
- use Griggs et al.'s study of reflective-learning transfer to give an existing question clearer scholarly grounding rather than presenting the paper as the origin of a new question
- connect the paper's discussion of double-loop learning with a three-level distinction from coaching practice
- distinguish portable techniques from a more durable capacity to notice, question, and help shape changing contexts
- add the note to the Research Notes index

## Why

The note documents a continuing inquiry: how learning can remain available after a class or supported learning environment disappears. It makes explicit that the question preceded the paper, while showing how the paper strengthened the inquiry by identifying the interaction of workplace context, reflective processes, and transformation of the learner.

The central question is not whether a person can become independent of context. It is whether education can change the learner's relationship with context so that inquiry, reflection, and choice remain more available when managers, teams, organizations, pressures, or crises change.

## Evidence boundaries

- the source study is presented as a small qualitative, self-report study rather than causal proof
- the coaching levels are identified as a practice-based conceptual distinction, not an empirical model of learning transfer
- the note does not claim a perfect mapping between coaching levels and single-loop or double-loop learning
- no client cases, quotations, or identifying details are included

## Validation

- branch is based on the current `main` and is zero commits behind
- diff is limited to one new research note and one Research Notes index entry
- front matter declares the required English language, direction, locale, canonical permalink, evidence level, and privacy status
- internal links resolve to the existing Research Notes routes
- full Jekyll, content architecture, site integrity, and generated-link validation will run in GitHub Actions
