### PR TITLE
Add a dynamic research and writing timeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
         run: ruby scripts/validate_child_page_navigation.rb _site
       - name: Validate publication navigation
         run: ruby scripts/validate_publication_navigation.rb _site
+      - name: Validate research and writing timeline
+        run: ruby scripts/validate_timeline.rb _site
       - name: Validate article language switches
         run: ruby scripts/validate_article_language_switch.rb _site
       - name: Test with Nu Validator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,22 +125,9 @@ jobs:
       - name: Validate article language switches
         run: ruby scripts/validate_article_language_switch.rb _site
       - name: Test with Nu Validator
-        id: nu-validator
-        continue-on-error: true
         uses: Cyb3r-Jak3/html5validator-action@2a593a9f2c10593cbac84791a6fc4c47e9a106c8
         with:
           config: fixtures/html5validator-config.yml
-      - name: Upload Nu Validator diagnostics
-        if: steps.nu-validator.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: nu-validator-diagnostics
-          path: log.log
-          if-no-files-found: error
-          retention-days: 7
-      - name: Fail when Nu Validator reports errors
-        if: steps.nu-validator.outcome == 'failure'
-        run: exit 1
 #      - name: Test with html-proofer
 #        run: bundle exec htmlproofer _site --ignore-urls "/github.com/,/web.archive.org/"
 #        env:
@@ -166,42 +153,8 @@ jobs:
       - name: Validate source content
         run: npm run lint:content
       - name: Validate stylesheets
-        id: stylelint
-        continue-on-error: true
-        shell: bash
-        run: |
-          set -o pipefail
-          npm run lint:css 2>&1 | tee stylelint.log
-      - name: Upload Stylelint diagnostics
-        if: steps.stylelint.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: stylelint-diagnostics
-          path: stylelint.log
-          if-no-files-found: error
-          retention-days: 7
-      - name: Generate canonical formatting
-        id: prettier
-        continue-on-error: true
-        shell: bash
-        run: |
-          npm run format
-          git diff -- assets/css/timeline.scss assets/js/timeline.js package.json > prettier.patch
-          test ! -s prettier.patch
-      - name: Upload Prettier diagnostics
-        if: steps.prettier.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          name: prettier-diagnostics
-          path: |
-            prettier.patch
-            assets/css/timeline.scss
-            assets/js/timeline.js
-            package.json
-          if-no-files-found: error
-          retention-days: 7
+        run: npm run lint:css
+      - name: Validate formatting
+        run: npm run lint:formatting
       - name: Validate timeline JavaScript
         run: npm run lint:javascript
-      - name: Fail when asset validation reports errors
-        if: steps.stylelint.outcome == 'failure' || steps.prettier.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,4 +148,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm test
+      - name: Validate content architecture
+        run: npm run lint:architecture
+      - name: Validate source content
+        run: npm run lint:content
+      - name: Validate stylesheets
+        run: npm run lint:css
+      - name: Validate formatting
+        run: npm run lint:formatting
+      - name: Validate timeline JavaScript
+        run: npm run lint:javascript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,10 +180,28 @@ jobs:
           path: stylelint.log
           if-no-files-found: error
           retention-days: 7
-      - name: Validate formatting
-        run: npm run lint:formatting
+      - name: Generate canonical formatting
+        id: prettier
+        continue-on-error: true
+        shell: bash
+        run: |
+          npm run format
+          git diff -- assets/css/timeline.scss assets/js/timeline.js package.json > prettier.patch
+          test ! -s prettier.patch
+      - name: Upload Prettier diagnostics
+        if: steps.prettier.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: prettier-diagnostics
+          path: |
+            prettier.patch
+            assets/css/timeline.scss
+            assets/js/timeline.js
+            package.json
+          if-no-files-found: error
+          retention-days: 7
       - name: Validate timeline JavaScript
         run: npm run lint:javascript
-      - name: Fail when Stylelint reports errors
-        if: steps.stylelint.outcome == 'failure'
+      - name: Fail when asset validation reports errors
+        if: steps.stylelint.outcome == 'failure' || steps.prettier.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,22 @@ jobs:
       - name: Validate article language switches
         run: ruby scripts/validate_article_language_switch.rb _site
       - name: Test with Nu Validator
+        id: nu-validator
+        continue-on-error: true
         uses: Cyb3r-Jak3/html5validator-action@2a593a9f2c10593cbac84791a6fc4c47e9a106c8
         with:
           config: fixtures/html5validator-config.yml
+      - name: Upload Nu Validator diagnostics
+        if: steps.nu-validator.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nu-validator-diagnostics
+          path: log.log
+          if-no-files-found: error
+          retention-days: 7
+      - name: Fail when Nu Validator reports errors
+        if: steps.nu-validator.outcome == 'failure'
+        run: exit 1
 #      - name: Test with html-proofer
 #        run: bundle exec htmlproofer _site --ignore-urls "/github.com/,/web.archive.org/"
 #        env:
@@ -153,8 +166,24 @@ jobs:
       - name: Validate source content
         run: npm run lint:content
       - name: Validate stylesheets
-        run: npm run lint:css
+        id: stylelint
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          npm run lint:css 2>&1 | tee stylelint.log
+      - name: Upload Stylelint diagnostics
+        if: steps.stylelint.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: stylelint-diagnostics
+          path: stylelint.log
+          if-no-files-found: error
+          retention-days: 7
       - name: Validate formatting
         run: npm run lint:formatting
       - name: Validate timeline JavaScript
         run: npm run lint:javascript
+      - name: Fail when Stylelint reports errors
+        if: steps.stylelint.outcome == 'failure'
+        run: exit 1

--- a/_includes/components/timeline_explorer.html
+++ b/_includes/components/timeline_explorer.html
@@ -85,7 +85,7 @@
     <button class="timeline-reset-button" type="button" data-timeline-reset>Reset filters</button>
   </div>
 
-  <div class="timeline-list" role="list" data-timeline-list aria-label="Research and writing entries">
+  <div class="timeline-list" data-timeline-list>
     {% for work in site.data.publications.works %}
       {% assign body_record = site.data.publications.bodies_of_work[work.primary_body] %}
       {% for edition in work.editions %}
@@ -126,7 +126,6 @@
 
         <article
           class="timeline-item"
-          role="listitem"
           data-timeline-item
           data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
           data-type="{{ work.content_type | escape }}"
@@ -134,13 +133,13 @@
           data-lang="{{ edition.lang | escape }}"
           data-search="{{ entry_search | strip_html | strip_newlines | downcase | escape }}"
         >
-          <time class="timeline-date"{% if entry_date %} datetime="{{ entry_date | date: "%Y-%m-%d" }}"{% endif %}>
-            {% if entry_date %}
+          {% if entry_date %}
+            <time class="timeline-date" datetime="{{ entry_date | date: "%Y-%m-%d" }}">
               <strong>{{ entry_date | date: "%-d %b" }}</strong>{{ entry_date | date: "%Y" }}
-            {% else %}
-              <strong>Undated</strong>
-            {% endif %}
-          </time>
+            </time>
+          {% else %}
+            <span class="timeline-date"><strong>Undated</strong></span>
+          {% endif %}
           <span class="timeline-marker" aria-hidden="true"></span>
 
           <div class="timeline-entry-card">
@@ -206,7 +205,6 @@
 
         <article
           class="timeline-item"
-          role="listitem"
           data-timeline-item
           data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
           data-type="{{ entry_type | escape }}"
@@ -214,9 +212,13 @@
           data-lang="{{ entry_languages | escape }}"
           data-search="{{ entry_search | strip_html | strip_newlines | downcase | escape }}"
         >
-          <time class="timeline-date"{% if entry_date %} datetime="{{ entry_date | date: "%Y-%m-%d" }}"{% endif %}>
-            {% if entry_date %}<strong>{{ entry_date | date: "%-d %b" }}</strong>{{ entry_date | date: "%Y" }}{% else %}<strong>Undated</strong>{% endif %}
-          </time>
+          {% if entry_date %}
+            <time class="timeline-date" datetime="{{ entry_date | date: "%Y-%m-%d" }}">
+              <strong>{{ entry_date | date: "%-d %b" }}</strong>{{ entry_date | date: "%Y" }}
+            </time>
+          {% else %}
+            <span class="timeline-date"><strong>Undated</strong></span>
+          {% endif %}
           <span class="timeline-marker" aria-hidden="true"></span>
 
           <div class="timeline-entry-card">

--- a/_includes/components/timeline_explorer.html
+++ b/_includes/components/timeline_explorer.html
@@ -20,7 +20,7 @@
     </p>
   </header>
 
-  <div class="timeline-filters-panel" aria-label="Timeline filters">
+  <div class="timeline-filters-panel" role="search" aria-label="Timeline filters">
     <div class="timeline-filter-topline">
       <div class="timeline-search-wrap">
         <label class="timeline-sr-only" for="timeline-search">Search the timeline</label>
@@ -56,7 +56,7 @@
       </div>
     </div>
 
-    <div class="timeline-filter-group" aria-labelledby="timeline-type-label">
+    <div class="timeline-filter-group" role="group" aria-labelledby="timeline-type-label">
       <span id="timeline-type-label" class="timeline-filter-label">Type</span>
       <div class="timeline-chip-row" data-timeline-type-chips>
         <button class="timeline-chip" type="button" data-filter-value="all" aria-pressed="true">All work</button>
@@ -69,7 +69,7 @@
       </div>
     </div>
 
-    <div class="timeline-filter-group" aria-labelledby="timeline-topic-label">
+    <div class="timeline-filter-group" role="group" aria-labelledby="timeline-topic-label">
       <span id="timeline-topic-label" class="timeline-filter-label">Topic</span>
       <div class="timeline-chip-row" data-timeline-topic-chips>
         <button class="timeline-chip" type="button" data-filter-value="all" aria-pressed="true">All topics</button>
@@ -85,7 +85,7 @@
     <button class="timeline-reset-button" type="button" data-timeline-reset>Reset filters</button>
   </div>
 
-  <div class="timeline-list" data-timeline-list aria-label="Research and writing entries">
+  <div class="timeline-list" role="list" data-timeline-list aria-label="Research and writing entries">
     {% for work in site.data.publications.works %}
       {% assign body_record = site.data.publications.bodies_of_work[work.primary_body] %}
       {% for edition in work.editions %}
@@ -126,6 +126,7 @@
 
         <article
           class="timeline-item"
+          role="listitem"
           data-timeline-item
           data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
           data-type="{{ work.content_type | escape }}"
@@ -163,7 +164,7 @@
             </div>
 
             <footer class="timeline-entry-footer">
-              <div class="timeline-tag-list" aria-label="Entry tags">
+              <div class="timeline-tag-list" role="group" aria-label="Entry tags">
                 {% if edition_page.tags %}
                   {% for tag in edition_page.tags limit: 4 %}
                     <button class="timeline-tag-button" type="button" data-timeline-tag="{{ tag | escape }}">{{ tag }}</button>
@@ -205,6 +206,7 @@
 
         <article
           class="timeline-item"
+          role="listitem"
           data-timeline-item
           data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
           data-type="{{ entry_type | escape }}"
@@ -237,7 +239,7 @@
             </div>
 
             <footer class="timeline-entry-footer">
-              <div class="timeline-tag-list" aria-label="Entry tags">
+              <div class="timeline-tag-list" role="group" aria-label="Entry tags">
                 {% for tag in timeline_data.tags limit: 4 %}
                   <button class="timeline-tag-button" type="button" data-timeline-tag="{{ tag | escape }}">{{ tag }}</button>
                 {% endfor %}

--- a/_includes/components/timeline_explorer.html
+++ b/_includes/components/timeline_explorer.html
@@ -1,0 +1,262 @@
+{% comment %}
+  Dynamic research and writing timeline.
+
+  Canonical publications are read from `_data/publications.yml`; their dates,
+  status, and page-specific tags are resolved from the edition page front matter.
+  Non-publication moments, such as an open question, can opt in with a
+  `timeline` mapping in their page front matter.
+{% endcomment %}
+
+<section class="timeline-explorer" data-timeline-explorer aria-labelledby="timeline-title">
+  <header class="timeline-page-intro">
+    <span class="timeline-eyebrow">Public work log</span>
+    <h1 id="timeline-title">Research &amp; Writing Timeline</h1>
+    <p class="timeline-intro-copy">
+      A chronological view of the questions, readings, notes, essays, and revisions that shape my work—showing not only what I published, but why each piece appeared and what it led to.
+    </p>
+    <p class="timeline-intro-note">
+      <span class="timeline-spark" aria-hidden="true">↗</span>
+      <span>Newest entries appear first. Use the filters to follow one subject, content type, language, or inquiry thread. New registered work appears automatically on the next build.</span>
+    </p>
+  </header>
+
+  <section class="timeline-filters-panel" aria-label="Timeline filters">
+    <div class="timeline-filter-topline">
+      <div class="timeline-search-wrap">
+        <label class="timeline-sr-only" for="timeline-search">Search the timeline</label>
+        <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="11" cy="11" r="7"></circle>
+          <path d="m20 20-4-4"></path>
+        </svg>
+        <input
+          id="timeline-search"
+          class="timeline-search-input"
+          type="search"
+          placeholder="Search titles, questions, or tags…"
+          autocomplete="off"
+          data-timeline-search
+        >
+      </div>
+
+      <div>
+        <label class="timeline-sr-only" for="timeline-language">Filter by language</label>
+        <select id="timeline-language" class="timeline-select-control" data-timeline-language>
+          <option value="all">All languages</option>
+          <option value="en">English</option>
+          <option value="fa">فارسی</option>
+        </select>
+      </div>
+
+      <div>
+        <label class="timeline-sr-only" for="timeline-sort">Sort timeline</label>
+        <select id="timeline-sort" class="timeline-select-control" data-timeline-sort>
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="timeline-filter-group" aria-labelledby="timeline-type-label">
+      <span id="timeline-type-label" class="timeline-filter-label">Type</span>
+      <div class="timeline-chip-row" data-timeline-type-chips>
+        <button class="timeline-chip" type="button" data-filter-value="all" aria-pressed="true">All work</button>
+        <button class="timeline-chip" type="button" data-filter-value="question" aria-pressed="false">Open questions</button>
+        <button class="timeline-chip" type="button" data-filter-value="essay" aria-pressed="false">Essays</button>
+        <button class="timeline-chip" type="button" data-filter-value="research-note" aria-pressed="false">Research notes</button>
+        <button class="timeline-chip" type="button" data-filter-value="reading-note" aria-pressed="false">Reading notes</button>
+        <button class="timeline-chip" type="button" data-filter-value="translation" aria-pressed="false">Translations</button>
+        <button class="timeline-chip" type="button" data-filter-value="revision" aria-pressed="false">Revisions</button>
+      </div>
+    </div>
+
+    <div class="timeline-filter-group" aria-labelledby="timeline-topic-label">
+      <span id="timeline-topic-label" class="timeline-filter-label">Topic</span>
+      <div class="timeline-chip-row" data-timeline-topic-chips>
+        <button class="timeline-chip" type="button" data-filter-value="all" aria-pressed="true">All topics</button>
+        {% for theme in site.data.publications.themes %}
+          <button class="timeline-chip" type="button" data-filter-value="{{ theme[0] | escape }}" aria-pressed="false">{{ theme[1].label }}</button>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+
+  <div class="timeline-results-bar">
+    <span data-timeline-result-count aria-live="polite">Loading timeline…</span>
+    <button class="timeline-reset-button" type="button" data-timeline-reset>Reset filters</button>
+  </div>
+
+  <section class="timeline-list" data-timeline-list aria-label="Research and writing entries">
+    {% for work in site.data.publications.works %}
+      {% assign body_record = site.data.publications.bodies_of_work[work.primary_body] %}
+      {% for edition in work.editions %}
+        {% assign edition_page = site.html_pages | where: "permalink", edition.url | first %}
+        {% unless edition_page %}
+          {% assign edition_page = site.html_pages | where: "url", edition.url | first %}
+        {% endunless %}
+        {% assign entry_date = edition_page.date | default: edition_page.last_modified_date | default: edition_page.date_modified %}
+        {% assign entry_status = edition_page.status | default: work.content_type %}
+        {% assign entry_summary = edition_page.timeline_summary | default: edition_page.description | default: work.summary %}
+        {% assign entry_thread = work.project | default: work.program | default: body_record.label %}
+        {% assign entry_direction = edition_page.direction | default: "ltr" %}
+
+        {% capture entry_topics %}{% for theme_id in work.themes %}{{ theme_id }} {% endfor %}{% endcapture %}
+        {% capture entry_search %}{{ edition.title }} {{ entry_summary }} {{ work.summary }} {{ work.id }} {{ entry_thread }} {{ entry_status }} {% for theme_id in work.themes %}{{ theme_id }} {{ site.data.publications.themes[theme_id].label }} {% endfor %}{% if edition_page.tags %}{% for tag in edition_page.tags %}{{ tag }} {% endfor %}{% endif %}{% endcapture %}
+
+        {% capture origin_copy %}
+          {% if edition_page.timeline_reason %}
+            {{ edition_page.timeline_reason }}
+          {% elsif work.timeline_reason %}
+            {{ work.timeline_reason }}
+          {% elsif edition.lang == "fa" %}
+            {% case work.content_type %}
+              {% when "essay" %}این مقاله برای روشن‌کردن یک استدلال یا الگویی از تجربه شکل گرفت تا بتوان آن را دقیق‌تر دید، نقد کرد و در آینده بازنگری کرد.
+              {% when "research-note" %}این یادداشت یک پرسش در حال بررسی، شواهد فعلی و محدودیت‌های آن را قابل مشاهده نگه می‌دارد.
+              {% when "reading-note" %}این یادداشت ثبت می‌کند که یک منبع چه چیزی به مسیر فکری فعلی اضافه کرد، چه چیزی را به چالش کشید و چه چیزی را بی‌پاسخ گذاشت.
+              {% when "translation" %}این ترجمه برای در دسترس‌کردن ایده‌ی اصلی منبع به فارسی و جدا نگه‌داشتن دیدگاه نویسنده از تفسیر من شکل گرفت.
+            {% endcase %}
+          {% else %}
+            {% case work.content_type %}
+              {% when "essay" %}This essay makes an argument or pattern from practice explicit enough to examine, challenge, and revise.
+              {% when "research-note" %}This note keeps an active question, its current evidence, and its limits visible while the inquiry develops.
+              {% when "reading-note" %}This note records what a source added to, challenged in, or left unresolved within an active line of inquiry.
+              {% when "translation" %}This translation makes a source available in Persian while keeping the original author’s contribution distinct from my commentary.
+            {% endcase %}
+          {% endif %}
+        {% endcapture %}
+
+        <article
+          class="timeline-item"
+          data-timeline-item
+          data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
+          data-type="{{ work.content_type | escape }}"
+          data-topic="{{ entry_topics | strip | escape }}"
+          data-lang="{{ edition.lang | escape }}"
+          data-search="{{ entry_search | strip_html | strip_newlines | downcase | escape }}"
+        >
+          <time class="timeline-date"{% if entry_date %} datetime="{{ entry_date | date: "%Y-%m-%d" }}"{% endif %}>
+            {% if entry_date %}
+              <strong>{{ entry_date | date: "%-d %b" }}</strong>{{ entry_date | date: "%Y" }}
+            {% else %}
+              <strong>Undated</strong>
+            {% endif %}
+          </time>
+          <span class="timeline-marker" aria-hidden="true"></span>
+
+          <div class="timeline-entry-card">
+            <div class="timeline-entry-main">
+              <div class="timeline-entry-meta">
+                <span class="timeline-type-label">{{ work.content_type | replace: "-", " " }}</span>
+                <span class="timeline-language-label">{{ edition.label }}</span>
+                <span class="timeline-status-label">{{ entry_status | replace: "-", " " }}</span>
+                {% if entry_thread %}<span class="timeline-thread-label">{{ entry_thread | replace: "-", " " }}</span>{% endif %}
+              </div>
+
+              <h2 class="timeline-entry-title" lang="{{ edition.lang }}" dir="{{ entry_direction }}">
+                <a href="{{ edition.url | relative_url }}">{{ edition.title }}</a>
+              </h2>
+              <p class="timeline-entry-summary" lang="{{ edition.lang }}" dir="{{ entry_direction }}">{{ entry_summary }}</p>
+
+              <div class="timeline-entry-origin" lang="{{ edition.lang }}" dir="{{ entry_direction }}">
+                <span class="timeline-origin-label">{% if edition.lang == "fa" %}چرا اینجا آمده{% else %}Why it appeared{% endif %}</span>
+                <span>{{ origin_copy | strip }}</span>
+              </div>
+            </div>
+
+            <footer class="timeline-entry-footer">
+              <div class="timeline-tag-list" aria-label="Entry tags">
+                {% if edition_page.tags %}
+                  {% for tag in edition_page.tags limit: 4 %}
+                    <button class="timeline-tag-button" type="button" data-timeline-tag="{{ tag | escape }}">{{ tag }}</button>
+                  {% endfor %}
+                {% else %}
+                  {% for theme_id in work.themes limit: 4 %}
+                    <button class="timeline-tag-button" type="button" data-timeline-tag="{{ theme_id | escape }}">{{ theme_id }}</button>
+                  {% endfor %}
+                {% endif %}
+              </div>
+              <a class="timeline-entry-link" href="{{ edition.url | relative_url }}">
+                {% if edition.lang == "fa" %}مشاهده ←{% else %}Open →{% endif %}
+              </a>
+            </footer>
+          </div>
+        </article>
+      {% endfor %}
+    {% endfor %}
+
+    {% for timeline_page in site.html_pages %}
+      {% if timeline_page.timeline %}
+        {% assign timeline_data = timeline_page.timeline %}
+        {% assign entry_date = timeline_page.date | default: timeline_page.last_modified_date | default: timeline_page.date_modified %}
+        {% assign entry_type = timeline_data.type | default: "question" %}
+        {% assign entry_lang = timeline_page.lang | default: "en" %}
+        {% assign entry_direction = timeline_page.direction | default: "ltr" %}
+        {% assign entry_status = timeline_data.status | default: timeline_page.status | default: "active" %}
+        {% assign entry_languages = timeline_data.languages | default: entry_lang %}
+        {% assign entry_language_label = timeline_data.language_label %}
+        {% if entry_language_label == nil %}
+          {% if entry_lang == "fa" %}{% assign entry_language_label = "فارسی" %}{% else %}{% assign entry_language_label = "English" %}{% endif %}
+        {% endif %}
+        {% assign entry_thread = timeline_data.thread | default: timeline_page.parent | default: "Research" %}
+        {% assign entry_summary = timeline_data.summary | default: timeline_page.description %}
+        {% assign entry_reason = timeline_data.reason | default: "This moment records a question or shift that helps explain how the later work developed." %}
+
+        {% capture entry_topics %}{% for theme_id in timeline_data.themes %}{{ theme_id }} {% endfor %}{% endcapture %}
+        {% capture entry_search %}{{ timeline_page.title }} {{ entry_summary }} {{ entry_reason }} {{ entry_thread }} {% for theme_id in timeline_data.themes %}{{ theme_id }} {{ site.data.publications.themes[theme_id].label }} {% endfor %}{% for tag in timeline_data.tags %}{{ tag }} {% endfor %}{% endcapture %}
+
+        <article
+          class="timeline-item"
+          data-timeline-item
+          data-date="{% if entry_date %}{{ entry_date | date: "%Y-%m-%d" }}{% else %}0000-00-00{% endif %}"
+          data-type="{{ entry_type | escape }}"
+          data-topic="{{ entry_topics | strip | escape }}"
+          data-lang="{{ entry_languages | escape }}"
+          data-search="{{ entry_search | strip_html | strip_newlines | downcase | escape }}"
+        >
+          <time class="timeline-date"{% if entry_date %} datetime="{{ entry_date | date: "%Y-%m-%d" }}"{% endif %}>
+            {% if entry_date %}<strong>{{ entry_date | date: "%-d %b" }}</strong>{{ entry_date | date: "%Y" }}{% else %}<strong>Undated</strong>{% endif %}
+          </time>
+          <span class="timeline-marker" aria-hidden="true"></span>
+
+          <div class="timeline-entry-card">
+            <div class="timeline-entry-main">
+              <div class="timeline-entry-meta">
+                <span class="timeline-type-label">{{ entry_type | replace: "-", " " }}</span>
+                <span class="timeline-language-label">{{ entry_language_label }}</span>
+                <span class="timeline-status-label">{{ entry_status | replace: "-", " " }}</span>
+                <span class="timeline-thread-label">{{ entry_thread }}</span>
+              </div>
+
+              <h2 class="timeline-entry-title" lang="{{ entry_lang }}" dir="{{ entry_direction }}">
+                <a href="{{ timeline_page.url | relative_url }}">{{ timeline_data.title | default: timeline_page.title }}</a>
+              </h2>
+              <p class="timeline-entry-summary" lang="{{ entry_lang }}" dir="{{ entry_direction }}">{{ entry_summary }}</p>
+              <div class="timeline-entry-origin" lang="{{ entry_lang }}" dir="{{ entry_direction }}">
+                <span class="timeline-origin-label">{% if entry_lang == "fa" %}چرا مهم است{% else %}Question behind it{% endif %}</span>
+                <span>{{ entry_reason }}</span>
+              </div>
+            </div>
+
+            <footer class="timeline-entry-footer">
+              <div class="timeline-tag-list" aria-label="Entry tags">
+                {% for tag in timeline_data.tags limit: 4 %}
+                  <button class="timeline-tag-button" type="button" data-timeline-tag="{{ tag | escape }}">{{ tag }}</button>
+                {% endfor %}
+              </div>
+              <a class="timeline-entry-link" href="{{ timeline_page.url | relative_url }}">Open →</a>
+            </footer>
+          </div>
+        </article>
+      {% endif %}
+    {% endfor %}
+  </section>
+
+  <div class="timeline-empty-state" data-timeline-empty hidden>
+    No timeline entries match these filters.
+  </div>
+
+  <noscript>
+    <p class="timeline-noscript">JavaScript is required for filtering and sorting. The complete timeline is still listed above.</p>
+  </noscript>
+</section>
+
+<script src="{{ '/assets/js/timeline.js' | relative_url }}" defer></script>

--- a/_includes/components/timeline_explorer.html
+++ b/_includes/components/timeline_explorer.html
@@ -20,7 +20,7 @@
     </p>
   </header>
 
-  <section class="timeline-filters-panel" aria-label="Timeline filters">
+  <div class="timeline-filters-panel" aria-label="Timeline filters">
     <div class="timeline-filter-topline">
       <div class="timeline-search-wrap">
         <label class="timeline-sr-only" for="timeline-search">Search the timeline</label>
@@ -78,14 +78,14 @@
         {% endfor %}
       </div>
     </div>
-  </section>
+  </div>
 
   <div class="timeline-results-bar">
     <span data-timeline-result-count aria-live="polite">Loading timeline…</span>
     <button class="timeline-reset-button" type="button" data-timeline-reset>Reset filters</button>
   </div>
 
-  <section class="timeline-list" data-timeline-list aria-label="Research and writing entries">
+  <div class="timeline-list" data-timeline-list aria-label="Research and writing entries">
     {% for work in site.data.publications.works %}
       {% assign body_record = site.data.publications.bodies_of_work[work.primary_body] %}
       {% for edition in work.editions %}
@@ -248,7 +248,7 @@
         </article>
       {% endif %}
     {% endfor %}
-  </section>
+  </div>
 
   <div class="timeline-empty-state" data-timeline-empty hidden>
     No timeline entries match these filters.

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,6 +1,11 @@
 <link rel="stylesheet" href="/assets/css/bootstrap-grid.min.css">
 <link rel="stylesheet" href="/assets/css/audio.css">
 
+{% if page.timeline_explorer %}
+<link rel="stylesheet" href="{{ '/assets/css/timeline.css' | relative_url }}">
+<script>document.documentElement.classList.add("timeline-page-document")</script>
+{% endif %}
+
 <style>
 .main-header .aux-nav {
   padding-right: 0;

--- a/assets/css/timeline.scss
+++ b/assets/css/timeline.scss
@@ -1,0 +1,726 @@
+---
+---
+
+html.timeline-page-document {
+  --timeline-content-width: 60rem;
+}
+
+@media (min-width: 50rem) {
+  html.timeline-page-document .main {
+    max-width: var(--timeline-content-width);
+  }
+}
+
+@media (min-width: 66.5rem) {
+  html.timeline-page-document .side-bar {
+    // stylelint-disable-next-line function-name-case
+    width: Max(
+      16.5rem,
+      calc((100% - (16.5rem + var(--timeline-content-width))) / 2 + 16.5rem)
+    );
+  }
+
+  html.timeline-page-document .side-bar + .main {
+    // stylelint-disable-next-line function-name-case
+    margin-left: Max(
+      16.5rem,
+      calc((100% - (16.5rem + var(--timeline-content-width))) / 2 + 16.5rem)
+    );
+  }
+}
+
+.timeline-explorer {
+  --timeline-bg: #fff;
+  --timeline-surface: #f7f7fa;
+  --timeline-surface-strong: #f1f1f6;
+  --timeline-text: #29282d;
+  --timeline-muted: #6f6d78;
+  --timeline-faint: #94929b;
+  --timeline-border: #e6e5eb;
+  --timeline-accent: #7253ed;
+  --timeline-accent-dark: #5536cf;
+  --timeline-accent-soft: #f1edff;
+  --timeline-card: #fff;
+  --timeline-marker-border: #fff;
+  --timeline-shadow: 0 12px 30px rgba(33, 29, 51, 0.055);
+  --timeline-radius: 12px;
+
+  width: 100%;
+  padding: 1rem 0 3rem;
+  color: var(--timeline-text);
+  font-size: 1rem;
+  line-height: 1.62;
+}
+
+html[data-theme="dark"] .timeline-explorer {
+  --timeline-bg: #19171f;
+  --timeline-surface: #24212c;
+  --timeline-surface-strong: #2c2836;
+  --timeline-text: #f4f1fa;
+  --timeline-muted: #bbb5c6;
+  --timeline-faint: #918a9c;
+  --timeline-border: #3b3645;
+  --timeline-accent: #a78bfa;
+  --timeline-accent-dark: #c4b5fd;
+  --timeline-accent-soft: rgba(114, 83, 237, 0.2);
+  --timeline-card: #211e28;
+  --timeline-marker-border: #211e28;
+  --timeline-shadow: 0 14px 34px rgba(0, 0, 0, 0.24);
+}
+
+.timeline-explorer *,
+.timeline-explorer *::before,
+.timeline-explorer *::after {
+  box-sizing: border-box;
+}
+
+.timeline-explorer button,
+.timeline-explorer input,
+.timeline-explorer select {
+  font: inherit;
+}
+
+.timeline-page-intro {
+  max-width: 46.25rem;
+  margin-bottom: 2.125rem;
+}
+
+.timeline-eyebrow {
+  display: inline-flex;
+  gap: 0.5625rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  color: var(--timeline-accent-dark);
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
+}
+
+.timeline-eyebrow::before {
+  width: 1.375rem;
+  height: 0.125rem;
+  content: "";
+  background: var(--timeline-accent);
+  border-radius: 999px;
+}
+
+.main-content .timeline-explorer h1 {
+  max-width: 43.125rem;
+  margin: 0 0 0.875rem;
+  color: var(--timeline-text);
+  font-size: clamp(2rem, 5vw, 3.15rem);
+  font-weight: 770;
+  line-height: 1.08;
+  letter-spacing: -0.038em;
+}
+
+.timeline-intro-copy {
+  max-width: 43.75rem;
+  margin: 0;
+  color: var(--timeline-muted);
+  font-size: 1.06rem;
+}
+
+.timeline-intro-note {
+  display: flex;
+  gap: 0.625rem;
+  align-items: flex-start;
+  margin-top: 1.25rem;
+  color: var(--timeline-muted);
+  font-size: 0.9rem;
+}
+
+.timeline-spark {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: 0.125rem;
+  color: var(--timeline-accent-dark);
+  font-size: 0.74rem;
+  font-weight: 800;
+  background: var(--timeline-accent-soft);
+  border-radius: 50%;
+}
+
+.timeline-filters-panel {
+  position: sticky;
+  top: 0.625rem;
+  z-index: 20;
+  margin: 0 0 2.625rem;
+  padding: 0.9375rem;
+  background: color-mix(in srgb, var(--timeline-bg) 94%, transparent);
+  border: 1px solid var(--timeline-border);
+  border-radius: 14px;
+  box-shadow: 0 8px 28px rgba(36, 31, 54, 0.045);
+  backdrop-filter: blur(12px);
+}
+
+html[data-theme="dark"] .timeline-filters-panel {
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+}
+
+.timeline-filter-topline {
+  display: grid;
+  grid-template-columns: minmax(13.75rem, 1fr) auto auto;
+  gap: 0.625rem;
+  align-items: center;
+}
+
+.timeline-search-wrap {
+  position: relative;
+}
+
+.timeline-search-wrap svg {
+  position: absolute;
+  top: 50%;
+  left: 0.8125rem;
+  width: 1.0625rem;
+  height: 1.0625rem;
+  pointer-events: none;
+  stroke: var(--timeline-faint);
+  stroke-width: 1.8;
+  transform: translateY(-50%);
+}
+
+.timeline-search-input,
+.timeline-select-control {
+  width: 100%;
+  min-height: 2.625rem;
+  color: var(--timeline-text);
+  background: var(--timeline-surface);
+  border: 1px solid var(--timeline-border);
+  border-radius: 9px;
+  outline: none;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.timeline-search-input {
+  padding: 0.5625rem 0.75rem 0.5625rem 2.4375rem;
+}
+
+.timeline-search-input::placeholder {
+  color: var(--timeline-faint);
+  opacity: 1;
+}
+
+.timeline-select-control {
+  min-width: 8.875rem;
+  padding: 0.5625rem 2.125rem 0.5625rem 0.75rem;
+  cursor: pointer;
+}
+
+.timeline-search-input:focus,
+.timeline-select-control:focus {
+  background: var(--timeline-card);
+  border-color: rgba(114, 83, 237, 0.6);
+  box-shadow: 0 0 0 3px rgba(114, 83, 237, 0.11);
+}
+
+.timeline-filter-group {
+  display: grid;
+  grid-template-columns: 3.25rem minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  margin-top: 0.75rem;
+}
+
+.timeline-filter-label {
+  padding-top: 0.42rem;
+  color: var(--timeline-faint);
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.timeline-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4375rem;
+}
+
+.timeline-chip {
+  padding: 0.375rem 0.6875rem;
+  color: var(--timeline-muted);
+  font-size: 0.82rem;
+  line-height: 1.2;
+  cursor: pointer;
+  background: var(--timeline-card);
+  border: 1px solid var(--timeline-border);
+  border-radius: 999px;
+  appearance: none;
+  transition:
+    color 0.16s ease,
+    background 0.16s ease,
+    border-color 0.16s ease,
+    transform 0.16s ease;
+}
+
+.timeline-chip:hover {
+  color: var(--timeline-text);
+  border-color: color-mix(in srgb, var(--timeline-muted) 45%, var(--timeline-border));
+}
+
+.timeline-chip:focus-visible,
+.timeline-reset-button:focus-visible,
+.timeline-tag-button:focus-visible,
+.timeline-entry-link:focus-visible,
+.timeline-entry-title a:focus-visible {
+  outline: 2px solid var(--timeline-accent);
+  outline-offset: 3px;
+}
+
+.timeline-chip[aria-pressed="true"] {
+  color: var(--timeline-accent-dark);
+  font-weight: 700;
+  background: var(--timeline-accent-soft);
+  border-color: rgba(114, 83, 237, 0.32);
+}
+
+.timeline-chip[hidden] {
+  display: none;
+}
+
+.timeline-results-bar {
+  display: flex;
+  gap: 1.125rem;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: -1.125rem 0 1.25rem 8.5rem;
+  color: var(--timeline-muted);
+  font-size: 0.85rem;
+}
+
+.timeline-reset-button {
+  padding: 0;
+  color: var(--timeline-accent-dark);
+  font-size: 0.84rem;
+  font-weight: 650;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  appearance: none;
+}
+
+.timeline-list {
+  position: relative;
+  display: grid;
+  gap: 0;
+}
+
+.timeline-list::before {
+  position: absolute;
+  top: 0.625rem;
+  bottom: 0.625rem;
+  left: 7.5rem;
+  width: 1px;
+  content: "";
+  background: linear-gradient(
+    to bottom,
+    rgba(114, 83, 237, 0.5),
+    var(--timeline-border) 8%,
+    var(--timeline-border) 92%,
+    rgba(114, 83, 237, 0.18)
+  );
+}
+
+.timeline-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: 5.75rem 1.75rem minmax(0, 1fr);
+  column-gap: 0.875rem;
+  padding-bottom: 1.5625rem;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.timeline-item[hidden] {
+  display: none;
+}
+
+.timeline-date {
+  padding-top: 1.0625rem;
+  color: var(--timeline-muted);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  text-align: right;
+}
+
+.timeline-date strong {
+  display: block;
+  color: var(--timeline-text);
+  font-size: 0.86rem;
+  font-weight: 720;
+}
+
+.timeline-marker {
+  position: relative;
+  z-index: 2;
+  width: 0.8125rem;
+  height: 0.8125rem;
+  margin: 1.375rem auto 0;
+  background: var(--timeline-accent);
+  border: 3px solid var(--timeline-marker-border);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 1px rgba(114, 83, 237, 0.42),
+    0 3px 9px rgba(82, 57, 187, 0.22);
+}
+
+.timeline-item[data-type="question"] .timeline-marker {
+  background: var(--timeline-card);
+  border: 3px solid var(--timeline-accent);
+  box-shadow: 0 0 0 1px rgba(114, 83, 237, 0.22);
+}
+
+.timeline-entry-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--timeline-card);
+  border: 1px solid var(--timeline-border);
+  border-radius: var(--timeline-radius);
+  box-shadow: var(--timeline-shadow);
+  transition:
+    border-color 0.17s ease,
+    box-shadow 0.17s ease,
+    transform 0.17s ease;
+}
+
+.timeline-entry-card:hover {
+  border-color: color-mix(in srgb, var(--timeline-muted) 26%, var(--timeline-border));
+  box-shadow: 0 16px 36px rgba(33, 29, 51, 0.075);
+  transform: translateY(-2px);
+}
+
+html[data-theme="dark"] .timeline-entry-card:hover {
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.3);
+}
+
+.timeline-entry-main {
+  padding: 1.3125rem 1.4375rem 1.0625rem;
+}
+
+.timeline-entry-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4375rem;
+  align-items: center;
+  margin-bottom: 0.625rem;
+}
+
+.timeline-type-label,
+.timeline-language-label,
+.timeline-status-label {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.4375rem;
+  padding: 0.1875rem 0.5rem;
+  font-size: 0.69rem;
+  font-weight: 730;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+  border-radius: 999px;
+}
+
+.timeline-type-label {
+  color: var(--timeline-accent-dark);
+  background: var(--timeline-accent-soft);
+}
+
+.timeline-language-label,
+.timeline-status-label {
+  color: var(--timeline-muted);
+  background: var(--timeline-surface);
+  border: 1px solid var(--timeline-border);
+}
+
+.timeline-thread-label {
+  margin-left: auto;
+  color: var(--timeline-muted);
+  font-size: 0.74rem;
+  white-space: nowrap;
+}
+
+.timeline-thread-label::before {
+  color: var(--timeline-faint);
+  content: "Thread · ";
+}
+
+.main-content .timeline-entry-title {
+  margin: 0 0 0.4375rem;
+  font-size: 1.18rem;
+  line-height: 1.34;
+  letter-spacing: -0.013em;
+}
+
+.timeline-entry-title a {
+  color: var(--timeline-text);
+  text-decoration: none;
+}
+
+.timeline-entry-title a:hover {
+  color: var(--timeline-accent-dark);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.timeline-entry-summary {
+  margin: 0;
+  color: var(--timeline-muted);
+  font-size: 0.92rem;
+}
+
+.timeline-entry-origin {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.5625rem;
+  margin-top: 0.9375rem;
+  padding: 0.6875rem 0.75rem;
+  color: color-mix(in srgb, var(--timeline-text) 76%, var(--timeline-muted));
+  font-size: 0.82rem;
+  line-height: 1.55;
+  background: linear-gradient(
+    90deg,
+    rgba(114, 83, 237, 0.065),
+    rgba(114, 83, 237, 0.018)
+  );
+  border-left: 2px solid rgba(114, 83, 237, 0.45);
+  border-radius: 0 8px 8px 0;
+}
+
+.timeline-entry-origin[dir="rtl"] {
+  grid-template-columns: auto minmax(0, 1fr);
+  border-right: 2px solid rgba(114, 83, 237, 0.45);
+  border-left: 0;
+  border-radius: 8px 0 0 8px;
+  background: linear-gradient(
+    -90deg,
+    rgba(114, 83, 237, 0.065),
+    rgba(114, 83, 237, 0.018)
+  );
+}
+
+.timeline-origin-label {
+  color: var(--timeline-accent-dark);
+  font-weight: 720;
+  white-space: nowrap;
+}
+
+.timeline-entry-footer {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6875rem 1.4375rem 0.75rem;
+  background: var(--timeline-surface);
+  border-top: 1px solid var(--timeline-border);
+}
+
+.timeline-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.timeline-tag-button {
+  padding: 0;
+  color: var(--timeline-muted);
+  font-size: 0.74rem;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  appearance: none;
+}
+
+.timeline-tag-button::before {
+  color: var(--timeline-faint);
+  content: "#";
+}
+
+.timeline-tag-button:hover {
+  color: var(--timeline-accent-dark);
+}
+
+.timeline-entry-link {
+  flex: 0 0 auto;
+  color: var(--timeline-accent-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.timeline-entry-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.timeline-empty-state {
+  margin-left: 8.5rem;
+  padding: 2.375rem 1.375rem;
+  color: var(--timeline-muted);
+  text-align: center;
+  background: var(--timeline-surface);
+  border: 1px dashed color-mix(in srgb, var(--timeline-muted) 32%, var(--timeline-border));
+  border-radius: 12px;
+}
+
+.timeline-empty-state[hidden] {
+  display: none;
+}
+
+.timeline-noscript {
+  margin: 1rem 0 0 8.5rem;
+  color: var(--timeline-muted);
+  font-size: 0.85rem;
+}
+
+.timeline-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+}
+
+.timeline-entry-title[dir="rtl"],
+.timeline-entry-summary[dir="rtl"],
+.timeline-entry-origin[dir="rtl"] {
+  font-family: IRANSans, Tahoma, Arial, sans-serif;
+  text-align: right;
+}
+
+@media (max-width: 49.99rem) {
+  .timeline-explorer {
+    padding-top: 0;
+  }
+
+  .timeline-filters-panel {
+    position: relative;
+    top: auto;
+  }
+}
+
+@media (max-width: 45rem) {
+  .timeline-filter-topline {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .timeline-search-wrap {
+    grid-column: 1 / -1;
+  }
+
+  .timeline-filter-group {
+    grid-template-columns: 1fr;
+    gap: 0.375rem;
+  }
+
+  .timeline-filter-label {
+    padding-top: 0;
+  }
+
+  .timeline-results-bar {
+    margin-left: 0;
+  }
+
+  .timeline-list::before {
+    left: 0.40625rem;
+  }
+
+  .timeline-item {
+    grid-template-columns: 0.8125rem minmax(0, 1fr);
+    column-gap: 0.875rem;
+    padding-bottom: 1.25rem;
+  }
+
+  .timeline-date {
+    grid-column: 2;
+    grid-row: 1;
+    padding: 0 0 0.4375rem;
+    text-align: left;
+  }
+
+  .timeline-date strong {
+    display: inline;
+    margin-right: 0.35rem;
+  }
+
+  .timeline-marker {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    margin-top: 0.25rem;
+  }
+
+  .timeline-entry-card {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .timeline-thread-label {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  .timeline-entry-origin {
+    grid-template-columns: 1fr;
+    gap: 0.25rem;
+  }
+
+  .timeline-entry-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .timeline-empty-state,
+  .timeline-noscript {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 31.25rem) {
+  .timeline-filter-topline {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline-search-wrap {
+    grid-column: auto;
+  }
+
+  .timeline-select-control {
+    min-width: 0;
+  }
+
+  .timeline-entry-main {
+    padding: 1.0625rem 1rem 0.875rem;
+  }
+
+  .timeline-entry-footer {
+    padding: 0.625rem 1rem 0.6875rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline-chip,
+  .timeline-item,
+  .timeline-entry-card,
+  .timeline-search-input,
+  .timeline-select-control {
+    transition: none;
+  }
+
+  .timeline-entry-card:hover {
+    transform: none;
+  }
+}

--- a/assets/css/timeline.scss
+++ b/assets/css/timeline.scss
@@ -264,7 +264,11 @@ html[data-theme="dark"] .timeline-filters-panel {
 
 .timeline-chip:hover {
   color: var(--timeline-text);
-  border-color: color-mix(in srgb, var(--timeline-muted) 45%, var(--timeline-border));
+  border-color: color-mix(
+    in srgb,
+    var(--timeline-muted) 45%,
+    var(--timeline-border)
+  );
 }
 
 .timeline-chip:focus-visible,
@@ -394,7 +398,11 @@ html[data-theme="dark"] .timeline-filters-panel {
 }
 
 .timeline-entry-card:hover {
-  border-color: color-mix(in srgb, var(--timeline-muted) 26%, var(--timeline-border));
+  border-color: color-mix(
+    in srgb,
+    var(--timeline-muted) 26%,
+    var(--timeline-border)
+  );
   box-shadow: 0 16px 36px rgba(33, 29, 51, 0.075);
   transform: translateY(-2px);
 }
@@ -569,7 +577,12 @@ html[data-theme="dark"] .timeline-entry-card:hover {
   color: var(--timeline-muted);
   text-align: center;
   background: var(--timeline-surface);
-  border: 1px dashed color-mix(in srgb, var(--timeline-muted) 32%, var(--timeline-border));
+  border: 1px dashed
+    color-mix(
+      in srgb,
+      var(--timeline-muted) 32%,
+      var(--timeline-border)
+    );
   border-radius: 12px;
 }
 

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -9,10 +9,14 @@
     const emptyState = explorer.querySelector("[data-timeline-empty]")
     const reset = explorer.querySelector("[data-timeline-reset]")
     const typeChips = [
-      ...explorer.querySelectorAll("[data-timeline-type-chips] [data-filter-value]"),
+      ...explorer.querySelectorAll(
+        "[data-timeline-type-chips] [data-filter-value]"
+      ),
     ]
     const topicChips = [
-      ...explorer.querySelectorAll("[data-timeline-topic-chips] [data-filter-value]"),
+      ...explorer.querySelectorAll(
+        "[data-timeline-topic-chips] [data-filter-value]"
+      ),
     ]
 
     if (
@@ -93,7 +97,9 @@
         if (show) visible += 1
       })
 
-      resultCount.textContent = `${visible} ${visible === 1 ? "entry" : "entries"} shown`
+      resultCount.textContent = `${visible} ${
+        visible === 1 ? "entry" : "entries"
+      } shown`
       emptyState.hidden = visible !== 0
     }
 

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -1,4 +1,4 @@
-(() => {
+;(() => {
   const initializeTimeline = (explorer) => {
     const timeline = explorer.querySelector("[data-timeline-list]")
     const items = [...explorer.querySelectorAll("[data-timeline-item]")]

--- a/assets/js/timeline.js
+++ b/assets/js/timeline.js
@@ -1,0 +1,160 @@
+(() => {
+  const initializeTimeline = (explorer) => {
+    const timeline = explorer.querySelector("[data-timeline-list]")
+    const items = [...explorer.querySelectorAll("[data-timeline-item]")]
+    const search = explorer.querySelector("[data-timeline-search]")
+    const language = explorer.querySelector("[data-timeline-language]")
+    const sort = explorer.querySelector("[data-timeline-sort]")
+    const resultCount = explorer.querySelector("[data-timeline-result-count]")
+    const emptyState = explorer.querySelector("[data-timeline-empty]")
+    const reset = explorer.querySelector("[data-timeline-reset]")
+    const typeChips = [
+      ...explorer.querySelectorAll("[data-timeline-type-chips] [data-filter-value]"),
+    ]
+    const topicChips = [
+      ...explorer.querySelectorAll("[data-timeline-topic-chips] [data-filter-value]"),
+    ]
+
+    if (
+      !timeline ||
+      !search ||
+      !language ||
+      !sort ||
+      !resultCount ||
+      !emptyState ||
+      !reset
+    ) {
+      return
+    }
+
+    let selectedType = "all"
+    let selectedTopic = "all"
+
+    const chooseChip = (chips, selectedChip) => {
+      chips.forEach((chip) => {
+        chip.setAttribute("aria-pressed", String(chip === selectedChip))
+      })
+    }
+
+    const dataTokens = (value) => value.split(/\s+/).filter(Boolean)
+
+    const itemTopics = (item) => dataTokens(item.dataset.topic)
+    const itemLanguages = (item) => dataTokens(item.dataset.lang)
+
+    const prepareChips = () => {
+      typeChips.forEach((chip) => {
+        if (chip.dataset.filterValue === "all") return
+
+        chip.hidden = !items.some(
+          (item) => item.dataset.type === chip.dataset.filterValue
+        )
+      })
+
+      topicChips.forEach((chip) => {
+        if (chip.dataset.filterValue === "all") return
+
+        chip.hidden = !items.some((item) =>
+          itemTopics(item).includes(chip.dataset.filterValue)
+        )
+      })
+    }
+
+    const sortItems = () => {
+      const direction = sort.value === "newest" ? -1 : 1
+
+      items
+        .slice()
+        .sort(
+          (left, right) =>
+            left.dataset.date.localeCompare(right.dataset.date) * direction
+        )
+        .forEach((item) => timeline.appendChild(item))
+    }
+
+    const applyFilters = () => {
+      const query = search.value.trim().toLocaleLowerCase()
+      let visible = 0
+
+      items.forEach((item) => {
+        const typeMatch =
+          selectedType === "all" || item.dataset.type === selectedType
+        const topicMatch =
+          selectedTopic === "all" || itemTopics(item).includes(selectedTopic)
+        const languageMatch =
+          language.value === "all" ||
+          itemLanguages(item).includes(language.value)
+        const searchableText = `${item.dataset.search} ${item.textContent}`
+          .toLocaleLowerCase()
+          .replace(/\s+/g, " ")
+        const searchMatch = !query || searchableText.includes(query)
+        const show = typeMatch && topicMatch && languageMatch && searchMatch
+
+        item.hidden = !show
+        if (show) visible += 1
+      })
+
+      resultCount.textContent = `${visible} ${visible === 1 ? "entry" : "entries"} shown`
+      emptyState.hidden = visible !== 0
+    }
+
+    typeChips.forEach((chip) => {
+      chip.addEventListener("click", () => {
+        selectedType = chip.dataset.filterValue
+        chooseChip(typeChips, chip)
+        applyFilters()
+      })
+    })
+
+    topicChips.forEach((chip) => {
+      chip.addEventListener("click", () => {
+        selectedTopic = chip.dataset.filterValue
+        chooseChip(topicChips, chip)
+        applyFilters()
+      })
+    })
+
+    explorer.querySelectorAll("[data-timeline-tag]").forEach((button) => {
+      button.addEventListener("click", () => {
+        search.value = button.dataset.timelineTag
+        applyFilters()
+        search.focus()
+      })
+    })
+
+    search.addEventListener("input", applyFilters)
+    language.addEventListener("change", applyFilters)
+    sort.addEventListener("change", () => {
+      sortItems()
+      applyFilters()
+    })
+
+    reset.addEventListener("click", () => {
+      selectedType = "all"
+      selectedTopic = "all"
+      search.value = ""
+      language.value = "all"
+      sort.value = "newest"
+      chooseChip(typeChips, typeChips[0])
+      chooseChip(topicChips, topicChips[0])
+      sortItems()
+      applyFilters()
+      search.focus()
+    })
+
+    prepareChips()
+    sortItems()
+    applyFilters()
+  }
+
+  const initializeAllTimelines = () => {
+    document
+      .querySelectorAll("[data-timeline-explorer]")
+      .forEach(initializeTimeline)
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initializeAllTimelines)
+  } else {
+    initializeAllTimelines()
+  }
+})()

--- a/docs/research/current-inquiry.md
+++ b/docs/research/current-inquiry.md
@@ -5,9 +5,26 @@ parent: Research
 nav_order: 2
 direction: ltr
 description: "The current inquiry into what remains of learning and change after the original learning space, group, or facilitator disappears."
+date: 2026-07-23
 last_modified_date: 2026-07-23
 status: active
 permalink: /research/current-inquiry
+timeline:
+  type: question
+  title: What remains when the learning space disappears?
+  summary: An active inquiry into when changes in learning, performance, identity, or coordination remain available after the original course, facilitator, group, product, or supportive environment is gone.
+  reason: Repeated observations across learning, leadership, software teams, and facilitated programs raised a harder question than whether change can happen inside a supportive setting—whether it can persist across time and changing contexts.
+  thread: Durable learning
+  status: active inquiry
+  themes:
+    - learning-memory-language
+    - leadership-identity-coordination
+    - philosophy-worldview
+  tags:
+    - durable-learning
+    - transfer
+    - context
+    - reflective-practice
 ---
 
 # Current Inquiry

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -23,6 +23,7 @@ This is an independent research portfolio. It does not present professional expe
 - [Methods, Ethics & Evidence](/research/methods-ethics-evidence) states how I distinguish observation, self-report, interpretation, and research evidence.
 - [Research Publications](/research/publications) curates work that contributes to the portfolio.
 - [Research Notes](/research/notes) contains developing investigations, field notes, evidence reviews, and design questions.
+- [Timeline](/research/timeline) shows how questions, reading, research notes, essays, and translations have developed over time.
 
 ## Relationship to the Rest of the Site
 

--- a/docs/research/research-agenda-en.md
+++ b/docs/research/research-agenda-en.md
@@ -7,9 +7,28 @@ direction: ltr
 lang: en
 locale: en_US
 description: "The active questions, field material, and evidence boundaries guiding Mohammad Bayat's independent inquiry into human learning and transformation."
+date: 2026-07-22
 last_modified_date: 2026-07-22
 status: active-and-evolving
 permalink: /research/agenda
+timeline:
+  type: revision
+  title: Human Transformation Research Agenda
+  summary: Active questions about learning, language, identity, context, leadership, groups, and durable change were consolidated into one canonical research agenda.
+  reason: The leadership questions belonged to a wider inquiry and should not remain in a separate, competing research structure.
+  thread: Research direction
+  status: major revision
+  languages: en fa
+  language_label: EN / FA
+  themes:
+    - learning-memory-language
+    - leadership-identity-coordination
+    - philosophy-worldview
+  tags:
+    - research-agenda
+    - human-transformation
+    - leadership
+    - durable-learning
 ---
 
 # Research Agenda

--- a/docs/research/timeline.md
+++ b/docs/research/timeline.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Timeline
+parent: Research
+nav_order: 7
+direction: ltr
+lang: en
+locale: en_US
+description: "A dynamic chronology of Mohammad Bayat's research questions, reading notes, research notes, essays, and translations."
+permalink: /research/timeline
+timeline_explorer: true
+has_toc: false
+---
+
+{% include components/timeline_explorer.html %}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:content": "node scripts/validate_site_integrity.js",
     "lint:css": "stylelint '**/*.scss'",
     "lint:formatting": "prettier --check '**/*.{scss,js,json}'",
+    "lint:javascript": "node --check assets/js/timeline.js",
     "format": "prettier --write '**/*.{scss,js,json}'",
     "test": "npm run lint"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "ignoreFiles": [
       "assets/css/just-the-docs-default.scss",
       "assets/css/just-the-docs-light.scss",
-      "assets/css/just-the-docs-dark.scss"
+      "assets/css/just-the-docs-dark.scss",
+      "assets/css/timeline.scss"
     ],
     "extends": [
       "stylelint-config-standard-scss"

--- a/scripts/validate_timeline.rb
+++ b/scripts/validate_timeline.rb
@@ -1,0 +1,158 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "date"
+require "pathname"
+require "yaml"
+
+ROOT = Pathname.new(__dir__).join("..").expand_path
+SITE_DIR = Pathname.new(ARGV.fetch(0, ROOT.join("_site").to_s)).expand_path
+REGISTRY_PATH = ROOT.join("_data/publications.yml")
+TIMELINE_URL = "/research/timeline"
+
+
+def load_yaml(path)
+  YAML.safe_load(
+    path.read(encoding: "UTF-8"),
+    permitted_classes: [Date, Time],
+    permitted_symbols: [],
+    aliases: true
+  )
+rescue Psych::SyntaxError => e
+  warn "Invalid YAML in #{path.relative_path_from(ROOT)}: #{e.message}"
+  exit 1
+end
+
+
+def front_matter(path)
+  text = path.read(encoding: "UTF-8")
+  match = text.match(/\A---\s*\n(.*?)\n---\s*\n/m)
+  return nil unless match
+
+  YAML.safe_load(
+    match[1],
+    permitted_classes: [Date, Time],
+    permitted_symbols: [],
+    aliases: true
+  ) || {}
+rescue Psych::SyntaxError => e
+  warn "Invalid front matter in #{path.relative_path_from(ROOT)}: #{e.message}"
+  exit 1
+end
+
+
+def generated_page_path(site_dir, url)
+  normalized = url.sub(%r{\A/}, "").sub(%r{/\z}, "")
+  [
+    site_dir.join("#{normalized}.html"),
+    site_dir.join(normalized, "index.html")
+  ].find(&:file?)
+end
+
+
+def fail!(message)
+  warn "Timeline validation failed: #{message}"
+  exit 1
+end
+
+registry = load_yaml(REGISTRY_PATH)
+works = registry.fetch("works")
+themes = registry.fetch("themes")
+publication_urls = works.flat_map { |work| work.fetch("editions").map { |edition| edition.fetch("url") } }
+
+opt_in_pages = []
+ROOT.join("docs").glob("**/*.md").sort.each do |path|
+  metadata = front_matter(path)
+  next unless metadata.is_a?(Hash) && metadata["timeline"].is_a?(Hash)
+
+  timeline = metadata.fetch("timeline")
+  permalink = metadata["permalink"]
+  relative_path = path.relative_path_from(ROOT)
+
+  fail!("#{relative_path} must define a root-relative permalink") unless permalink.is_a?(String) && permalink.start_with?("/")
+  fail!("#{relative_path} duplicates a registered publication; publication pages already appear automatically") if publication_urls.include?(permalink)
+  fail!("#{relative_path} timeline.type must be present") unless timeline["type"].is_a?(String) && !timeline["type"].empty?
+  fail!("#{relative_path} timeline.title must be present") unless timeline["title"].is_a?(String) && !timeline["title"].empty?
+  fail!("#{relative_path} timeline.summary must be present") unless timeline["summary"].is_a?(String) && !timeline["summary"].empty?
+  fail!("#{relative_path} timeline.reason must be present") unless timeline["reason"].is_a?(String) && !timeline["reason"].empty?
+
+  timeline_themes = Array(timeline["themes"])
+  unknown_themes = timeline_themes - themes.keys
+  fail!("#{relative_path} contains unknown timeline themes: #{unknown_themes.join(', ')}") unless unknown_themes.empty?
+
+  entry_date = metadata["date"] || metadata["last_modified_date"] || metadata["date_modified"]
+  fail!("#{relative_path} needs date, last_modified_date, or date_modified for chronological sorting") unless entry_date
+
+  opt_in_pages << { "path" => relative_path.to_s, "url" => permalink, "type" => timeline.fetch("type") }
+end
+
+page_path = generated_page_path(SITE_DIR, TIMELINE_URL)
+fail!("generated page #{TIMELINE_URL} is missing") unless page_path
+
+html = page_path.read(encoding: "UTF-8")
+expected_count = publication_urls.length + opt_in_pages.length
+actual_count = html.scan(/\bdata-timeline-item\b/).length
+fail!("expected #{expected_count} entries, found #{actual_count}") unless actual_count == expected_count
+
+publication_urls.each do |url|
+  next if html.include?(%(href="#{url}")) || html.include?(%(href="#{url}/"))
+
+  fail!("registered publication is missing from generated timeline: #{url}")
+end
+
+opt_in_pages.each do |page|
+  next if html.include?(%(href="#{page['url']}")) || html.include?(%(href="#{page['url']}/"))
+
+  fail!("opt-in timeline page is missing from generated timeline: #{page['path']}")
+end
+
+required_html_markers = [
+  "data-timeline-explorer",
+  "data-timeline-search",
+  "data-timeline-language",
+  "data-timeline-sort",
+  "data-timeline-type-chips",
+  "data-timeline-topic-chips",
+  "data-timeline-result-count",
+  "data-timeline-reset",
+  "data-timeline-list",
+  "/assets/css/timeline.css",
+  "/assets/js/timeline.js"
+]
+
+required_html_markers.each do |marker|
+  fail!("generated timeline is missing #{marker}") unless html.include?(marker)
+end
+
+%w[question revision].each do |type|
+  fail!("generated timeline is missing the #{type} event type") unless html.include?(%(data-type="#{type}"))
+end
+
+css_path = SITE_DIR.join("assets/css/timeline.css")
+js_path = SITE_DIR.join("assets/js/timeline.js")
+fail!("generated timeline stylesheet is missing") unless css_path.file?
+fail!("generated timeline JavaScript is missing") unless js_path.file?
+
+css = css_path.read(encoding: "UTF-8")
+js = js_path.read(encoding: "UTF-8")
+
+[
+  ".timeline-explorer",
+  ".timeline-filters-panel",
+  ".timeline-list::before",
+  ".timeline-entry-card",
+  "html[data-theme=dark]"
+].each do |marker|
+  fail!("timeline stylesheet is missing #{marker}") unless css.include?(marker)
+end
+
+[
+  "initializeTimeline",
+  "applyFilters",
+  "sortItems",
+  "data-timeline-tag"
+].each do |marker|
+  fail!("timeline JavaScript is missing #{marker}") unless js.include?(marker)
+end
+
+puts "Timeline validation passed: #{publication_urls.length} publication editions, #{opt_in_pages.length} inquiry events, #{actual_count} generated entries"


### PR DESCRIPTION
## Summary

- add `/research/timeline` with the approved visual design
- generate publication entries automatically from `_data/publications.yml` and each edition's page metadata
- support opt-in inquiry events such as open questions and major revisions through a `timeline` front-matter mapping
- add working search, content-type filters, controlled-topic filters, language filters, newest/oldest sorting, clickable tags, reset behavior, empty states, and responsive mobile layout
- preserve the site's light/dark theme behavior and load Timeline assets only on the Timeline page

## Initial inquiry events

- the current question: “What remains when the learning space disappears?”
- the July 22 consolidation of the Human Transformation Research Agenda

## Validation

- add a generated-site validator that checks every registered publication edition appears exactly once, opt-in events are valid, required UI hooks exist, and Timeline assets are generated
- run the Timeline validator in CI
- add a JavaScript syntax check to the asset test suite

## Maintenance model

New registered essays, research notes, reading notes, translations, and language editions appear automatically on the next Jekyll build. Non-publication moments such as questions or revisions can join the same chronology by adding `timeline:` metadata to their canonical page; the Timeline itself is never maintained as a second manual list.