### PR TITLE
Stack Timeline origin labels consistently

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -3,6 +3,13 @@
 
 {% if page.timeline_explorer %}
 <link rel="stylesheet" href="{{ '/assets/css/timeline.css' | relative_url }}">
+<style>
+.timeline-entry-origin,
+.timeline-entry-origin[dir="rtl"] {
+  grid-template-columns: minmax(0, 1fr);
+  gap: .25rem;
+}
+</style>
 <script>document.documentElement.classList.add("timeline-page-document")</script>
 {% endif %}
 


### PR DESCRIPTION
## Summary

- make the Timeline’s “Why it appeared” / «چرا اینجا آمده» block use one consistent vertical layout in both LTR and RTL editions
- keep the label on the first row and the explanatory text on the next row at every viewport width
- preserve the existing RTL border, gradient, typography, and alignment

## Why

The base Timeline grid used two columns on wider viewports. In RTL entries, that placed «چرا اینجا آمده» beside the explanation, while the English entry in the reported viewport appeared stacked. The override now gives both languages the same one-column structure.

## Scope

This is a focused follow-up to merged PR #85 and changes only the Timeline page’s origin-block layout.