### PR TITLE
Stop Timeline filters from sticking on scroll

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -9,6 +9,12 @@
   grid-template-columns: minmax(0, 1fr);
   gap: .25rem;
 }
+
+.timeline-filters-panel {
+  position: static;
+  top: auto;
+  z-index: auto;
+}
 </style>
 <script>document.documentElement.classList.add("timeline-page-document")</script>
 {% endif %}


### PR DESCRIPTION
## Summary

- remove the sticky positioning behavior from the filter panel on `/research/timeline`
- keep the panel’s existing visual styling and filtering behavior unchanged
- scope the override to Timeline pages only

## Result

The filter box now remains in the normal document flow and scrolls away with the rest of the page instead of attaching to the top of the viewport.