### PR TITLE
Add proposed master's research dossier page

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ About
 
 Research
 ├── Research Profile
-├── Current Inquiry
+├── Proposed Master's Research
 ├── Research Agenda
 ├── Methods, Ethics & Evidence
 ├── Research Publications
@@ -345,7 +345,7 @@ Reports with an explicit question, hypothesis, method, participants or dataset, 
 
 - `/research` — research portfolio overview;
 - `/research/profile` — practitioner-researcher identity and position;
-- `/research/current-inquiry` — the single highlighted current inquiry;
+- `/research/current-inquiry` — the single highlighted proposed master's research;
 - `/research/agenda` — wider active and open questions;
 - `/research/methods-ethics-evidence` — public evidence and participant-protection standard;
 - `/research/publications` — curated research-related discovery;

--- a/docs/leadership-learning/learning-facilitation/index.md
+++ b/docs/leadership-learning/learning-facilitation/index.md
@@ -27,4 +27,4 @@ This section examines facilitation as the design of conditions for learning—no
 - Which outcomes belong to the learning design, and which depend on selection, relationships, incentives, or the original setting?
 - What consent is required before material from a learning relationship is used publicly?
 
-Research-facing answers and evidence standards are maintained under [Research](/research), especially [Current Inquiry](/research/current-inquiry) and [Methods, Ethics & Evidence](/research/methods-ethics-evidence).
+Research-facing answers and evidence standards are maintained under [Research](/research), especially [Proposed Master's Research](/research/current-inquiry) and [Methods, Ethics & Evidence](/research/methods-ethics-evidence).

--- a/docs/research/current-inquiry.md
+++ b/docs/research/current-inquiry.md
@@ -1,67 +1,209 @@
 ---
 layout: default
-title: Current Inquiry
+title: Proposed Master's Research
 parent: Research
 nav_order: 2
 direction: ltr
-description: "The current inquiry into what remains of learning and change after the original learning space, group, or facilitator disappears."
+lang: en
+locale: en_US
+description: "A proposed six-month longitudinal, arts-informed qualitative study of how reflective practices persist, adapt, become concealed, erode, or reactivate across changing organizational contexts."
+author: Mohammad Bayat
 date: 2026-07-23
-last_modified_date: 2026-07-23
-status: active
+date_modified: 2026-07-24
+last_modified_date: 2026-07-24
+status: proposal-in-development
+seo:
+  type: Article
+sitemap: true
 permalink: /research/current-inquiry
 timeline:
   type: question
-  title: What remains when the learning space disappears?
-  summary: An active inquiry into when changes in learning, performance, identity, or coordination remain available after the original course, facilitator, group, product, or supportive environment is gone.
-  reason: Repeated observations across learning, leadership, software teams, and facilitated programs raised a harder question than whether change can happen inside a supportive setting—whether it can persist across time and changing contexts.
+  title: What happens to reflective practice when the learning space disappears?
+  summary: A proposed six-month longitudinal study of how adults carry, adapt, conceal, lose, or reactivate reflective practices after leaving a supportive learning community and entering changing organizational contexts.
+  reason: Repeated observations across learning, leadership, software teams, and facilitated programs raised a harder question than whether change can happen inside a supportive setting—how reflective practice develops when the setting changes.
   thread: Durable learning
-  status: active inquiry
+  status: proposed master's research
   themes:
     - learning-memory-language
     - leadership-identity-coordination
     - philosophy-worldview
   tags:
-    - durable-learning
-    - transfer
-    - context
     - reflective-practice
+    - learning-transfer
+    - organizational-context
+    - longitudinal-research
 ---
 
-# Current Inquiry
+# When the Learning Space Disappears
+{: .no_toc }
 
-{ What remains when the learning space disappears? | fs-6 }
+{ A longitudinal, arts-informed study of reflective practice across changing organizational contexts | fs-6 }
 
-## The Question
+{: .note-title }
+> **Proposed master's research · Draft for supervision and program discussion**
+>
+> This page presents a feasible research direction, not an approved protocol. The question, study site, recruitment strategy, and methods will be revised with supervisory guidance, institutional requirements, and research-ethics review before any formal data collection begins.
 
-Under what conditions does a change in learning, performance, identity, or coordination persist when the original course, facilitator, group, product, or supportive environment is no longer present?
+Supportive learning communities can make reflection, dialogue, experimentation, and new forms of action more available. The harder question begins when participants leave: what becomes of those practices when they enter workplaces with different expectations, power relations, time pressures, and norms?
 
-## Why It Matters
+This proposed study follows reflective practice as a trajectory rather than treating transfer as a single successful or unsuccessful outcome. A practice may persist openly, adapt to a new setting, move into private use, become temporarily unavailable, or return after a critical event. The study asks how people and contexts interact across those changes.
 
-A person may speak, act, or perform differently inside a powerful learning environment and later return to an earlier pattern. A group may coordinate well while a founder or facilitator is present and lose that capacity when the central figure steps back.
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
 
-If the change depends on the original setting, it may still be meaningful—but it should not be described as durable transfer or transformation without evidence across time and contexts.
+## Working research question
 
-## What Currently Informs the Inquiry
+> **How do adults' reflective practices persist, adapt, become concealed, erode, or reactivate during the six months after they leave a supportive learning community and move through changing organizational contexts?**
 
-- published work on learning, transfer, retrieval, spacing, identity, and group coordination;
-- professional experience in software organizations, leadership facilitation, coaching, and learning settings;
-- project questions arising from [Vocora](/projects/vocora);
-- practice-based records such as [Learning Circle](/leadership-learning/human-transformation/field-projects/learning-circle);
-- cases in which an apparent change weakened, remained context-bound, or could not be independently verified.
+Supporting questions are:
 
-These sources do not all have the same evidential weight. Professional observation and participant accounts help form questions; they do not establish causality or durability by themselves.
+1. Which features of a new organizational context appear to support, restrict, or reshape reflective practice?
+2. How do participants describe moments when reflection influences—or fails to influence—their action during uncertainty, conflict, failure, or change?
+3. When a reflective practice is no longer publicly visible, has it disappeared, become private, changed form, or become unsafe to express?
+4. What differences appear across participants whose practices follow different trajectories?
 
-## What Is Still Unknown
+The wording is deliberately open. It does not assume that every participant changed during the original program, that reflective practice is always beneficial, or that a less visible practice has necessarily been lost.
 
-- which changes are skills, temporary performance, identity claims, or durable transfer;
-- which parts of an outcome belong to the person and which belong to the environment;
-- how long and across how many settings a change should be observed;
-- what comparison or counterfactual would make an interpretation credible;
-- how facilitator influence and social desirability can be reduced;
-- which data can be collected and published ethically.
+## Why this question matters
 
-## Next Step
+Educational and leadership programs are often evaluated inside the environment that was designed to support them. Participants may report insight, demonstrate new language, or act differently while a facilitator, cohort, and shared routine are still present. These observations can be meaningful, but they do not establish what will remain later.
 
-The next step is to narrow one testable subquestion, define the outcome and time horizon before collecting data, separate facilitator and evaluator roles where possible, and obtain consent appropriate to the actual public or research use.
+Organizational contexts are not neutral destinations for learning. Workload, hierarchy, psychological safety, professional identity, peer relationships, and opportunities for dialogue can affect whether reflection is expressed or used. At the same time, participants are not only recipients of context: they may interpret it, negotiate with it, find allies, create small reflective spaces, or decide that visible reflection carries too much risk.
 
-The wider set of related questions remains in the [Research Agenda](/research/agenda).
+A longitudinal study can make these movements visible. It can also replace a simple question—“Did the learning transfer?”—with a more precise account of what changed, when, under which conditions, and through whose interpretation.
+
+## Conceptual starting point
+
+The proposal begins at the intersection of four bodies of work:
+
+- **reflective practice**, including reflection during and after professional action;
+- **learning transfer**, especially research that treats the workplace as part of the transfer process rather than as a passive setting;
+- **communities and cohorts**, which can provide language, relationships, feedback, and permission for inquiry;
+- **organizational context and power**, which shape what people can safely notice, question, disclose, and enact.
+
+My current [reading and inquiry note](/research/notes/can-the-learner-carry-the-context) examines one qualitative study of the movement from reflective learning to workplace practice. A fuller literature synthesis is the next scholarly output planned for this portfolio. It will test the assumptions behind this proposal, identify competing explanations, and refine the analytical vocabulary before the study begins.
+
+My [reading of Rosemary Reilly's arts-based action research](/research/notes/art-groupwork-communication-en) also informs the methodological direction. Reilly used artistic forms to help cohort members make difficult group experience available for collective inquiry. In this proposed study, an arts-informed element would have a different role: helping a participant revisit an experience across time without assuming that an interview alone can express it fully. That difference must remain explicit; an artifact would be an invitation to inquiry, not a diagnosis or transparent record of an inner state.
+
+## Proposed design
+
+### Approach
+
+The study would use a **longitudinal qualitative design** with optional arts-informed methods. Its purpose would be to understand processes and differences across trajectories, not to estimate a population-wide treatment effect or prove that a program caused later change.
+
+### Participants and setting
+
+The intended sample is approximately **8–12 adults** completing the same or a closely comparable cohort-based learning experience in which reflective practice is an explicit part of participation.
+
+The study site has not yet been selected. A suitable site would:
+
+- provide a clear transition point from a supportive learning community into ongoing organizational life;
+- allow recruitment without pressure from teachers, managers, or the researcher;
+- include participants moving into sufficiently varied organizational contexts;
+- permit six months of follow-up;
+- not depend on access to my former coaching clients or program participants.
+
+Final inclusion criteria and sample size would follow the research question, access conditions, supervisory guidance, and ethics review.
+
+### Six-month timeline
+
+Data collection would use four main checkpoints:
+
+| Checkpoint | Purpose |
+|---|---|
+| End of learning experience | Establish participants' current understanding of reflective practice, expectations, relationships, and anticipated contexts. |
+| One month later | Examine the first transition, early supports and constraints, and critical incidents. |
+| Three months later | Identify emerging patterns, adaptations, interruptions, and changes in context. |
+| Six months later | Reconstruct each trajectory, examine reactivation or erosion, and test the researcher's developing interpretation. |
+
+This duration is long enough to observe more than an immediate post-program response while remaining feasible for a master's project. It cannot establish lifelong durability.
+
+### Sources of material
+
+The proposed evidence would combine:
+
+- semi-structured interviews focused on concrete critical incidents;
+- participant-created context maps at selected checkpoints;
+- short, optional audio or text reflections recorded after relevant events;
+- optional arts-based artifacts when a participant finds images, metaphor, drawing, or another form more useful than immediate explanation;
+- a separately consented colleague perspective in a small subset of cases, if feasible and ethically appropriate.
+
+No single source would be treated as a direct measure of internal change. The purpose of combining sources is to compare what participants say, how their accounts develop over time, and what each method makes easier—or harder—to express.
+
+## Analysis
+
+Analysis would combine within-person and cross-case work:
+
+1. construct a chronological trajectory for each participant;
+2. code critical incidents, contextual conditions, reported practices, and changes in meaning;
+3. compare accounts and artifacts across checkpoints;
+4. examine differences among persistence, adaptation, concealment, erosion, and reactivation;
+5. actively search for negative cases that do not fit the developing interpretation;
+6. compare cases without forcing every participant into one fixed sequence.
+
+A reflexive research journal would document how my prior experience in facilitation and coaching shapes attention and interpretation. Participant feedback may help identify factual misunderstandings, but it would not be treated as automatic validation of the analysis.
+
+## Ethics, power, and researcher position
+
+My professional background gives me a strong interest in this question, but it also creates risks of confirmation bias and role confusion. I have facilitated leadership programs and coached people who later described how learning did—or did not—remain available. Those experiences generate questions; they are not proposed as master's research data.
+
+The formal study should therefore prefer participants for whom I have not been a coach, manager, teacher, or evaluator. Recruitment and consent should make clear that participation, refusal, and withdrawal have no effect on education, employment, or professional relationships.
+
+The study would also:
+
+- minimize collection of employer and colleague identifiers;
+- avoid reporting combinations of role, event, and timeline that make a person recognizable;
+- treat organizational criticism and workplace conflict as potentially sensitive material;
+- let participants skip a method or question without leaving the whole study;
+- define retention, access, withdrawal, and secure-storage procedures before collection;
+- obtain separate consent for any colleague contribution or public use of an artifact;
+- begin formal data collection only after the required institutional ethics approval.
+
+Arts-informed methods require particular care because a distinctive image, story, or artifact may remain identifiable even after names are removed.
+
+## Feasibility and boundaries
+
+The project is intentionally bounded:
+
+- one main learning setting;
+- a small qualitative sample;
+- six months of follow-up;
+- a limited set of repeated methods;
+- no claim of causal program effectiveness;
+- no claim that reflective practice is a stable personal trait;
+- no assumption that visible workplace behavior reveals the whole trajectory.
+
+The principal feasibility risks are participant attrition, uneven access to organizational contexts, excessive data volume, and the possibility that optional methods produce material too identifiable to report. The final protocol should reduce burden, set clear recording limits, and identify which method is essential if others prove impractical.
+
+## Expected contribution
+
+The intended contribution is a process account of reflective practice after a supportive learning community ends. The study may help distinguish among outcomes that are often collapsed into “transfer” or “non-transfer”:
+
+- continued public practice;
+- private continuation;
+- adaptation to local constraints;
+- temporary suppression;
+- erosion over time;
+- reactivation after a relationship, event, or contextual change.
+
+This distinction could help educators and organizational practitioners design more responsible follow-up, avoid overstating immediate outcomes, and understand when the problem is not that a learner forgot—but that a context changed what could be enacted or disclosed.
+
+## What remains to be decided
+
+Before this can become a formal proposal, I need to:
+
+1. complete a focused literature synthesis and sharpen the conceptual definitions;
+2. identify a feasible study site and access pathway;
+3. determine which arts-informed element adds real analytical value;
+4. refine recruitment, attrition, data-volume, and privacy plans;
+5. align the design with supervisory expertise and program expectations;
+6. develop the interview guide, context-map prompt, consent materials, and preliminary coding framework;
+7. submit the final protocol for the required ethics review.
+
+The proposal will change as those questions are answered. That revision is part of the research rather than a weakness to conceal.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -18,7 +18,7 @@ This is an independent research portfolio. It does not present professional expe
 ## Start Here
 
 - [Research Profile](/research/profile) explains the experience and questions that shape my identity as a practitioner-researcher.
-- [Current Inquiry](/research/current-inquiry) presents the central question I am pursuing now.
+- [Proposed Master's Research](/research/current-inquiry) presents the central question and a bounded six-month study design.
 - [Research Agenda](/research/agenda) records the wider set of active and open questions.
 - [Methods, Ethics & Evidence](/research/methods-ethics-evidence) states how I distinguish observation, self-report, interpretation, and research evidence.
 - [Research Publications](/research/publications) curates work that contributes to the portfolio.

--- a/docs/research/research-profile.md
+++ b/docs/research/research-profile.md
@@ -31,6 +31,6 @@ I therefore treat professional experience as a source of questions and bounded o
 
 ## Current Direction
 
-The [Current Inquiry](/research/current-inquiry) examines what allows learning or change to travel beyond the environment in which it was created. The broader [Research Agenda](/research/agenda) connects that question to language, identity, leadership, children’s independent learning, group coordination, and quality of life.
+The [Proposed Master's Research](/research/current-inquiry) examines how reflective practices persist, adapt, become concealed, erode, or reactivate after adults leave a supportive learning community and enter changing organizational contexts. The broader [Research Agenda](/research/agenda) connects that question to language, identity, leadership, children’s independent learning, group coordination, and quality of life.
 
 My approach to evidence and participant protection is stated in [Methods, Ethics & Evidence](/research/methods-ethics-evidence).

--- a/index.md
+++ b/index.md
@@ -15,25 +15,25 @@ I build quantitative systems and organizations, and I study how language, identi
 
 OkBayat.com is a research and practice portfolio: a public record of what I am building, what I am asking, what evidence is available, where the limits are, and how the work changes.
 
-## Current Inquiry
+## Proposed Master's Research
 
-**What remains when the learning space disappears?**
+**What happens to reflective practice when the learning space disappears?**
 
-I am examining what allows learning, performance, identity, or group coordination to persist after the original course, facilitator, team, product, or supportive context is no longer present.
+I am developing a six-month longitudinal, arts-informed qualitative study of how reflective practices persist, adapt, become concealed, erode, or reactivate after adults leave a supportive learning community and enter changing organizational contexts.
 
-[Read the current inquiry](/research/current-inquiry) · [View the research profile](/research/profile)
+[Read the proposed master's research](/research/current-inquiry) · [View the research profile](/research/profile)
 
 ## Selected Work
 
 <div class="evidence-card-grid">
 {% include components/evidence_card.html
-  type="Research direction"
-  status="Active"
-  title="What Remains When the Learning Space Disappears?"
-  question="What distinguishes durable transfer from change that depends on the original context?"
+  type="Proposed master's research"
+  status="In development"
+  title="When the Learning Space Disappears"
+  question="How do reflective practices persist, adapt, become concealed, erode, or reactivate across changing organizational contexts?"
   role="Practitioner-researcher"
-  evidence="Published sources, bounded field records, professional observation, and explicit open questions"
-  limits="No causal or universal claim; study design is still being narrowed"
+  evidence="A bounded six-month longitudinal qualitative design informed by published sources and explicit methodological limits"
+  limits="Not yet an approved protocol; site, access, methods, and ethics plan remain subject to supervision and review"
   url="/research/current-inquiry"
 %}
 {% include components/evidence_card.html


### PR DESCRIPTION
## What changed

- turns the existing Current Inquiry page into a focused proposed master's research page
- defines the working question, six-month longitudinal design, participant scope, checkpoints, material sources, analysis, ethics, feasibility, and boundaries
- explains how the existing reflective-practice and arts-based reading notes inform the proposal without implying approval or supervision
- aligns the homepage, Research index, Research Profile, facilitation index, and editorial guide with the new page title

## Why

The research portfolio needs one concise, assessable page that can later be shared with a prospective supervisor. The previous page stated a broad inquiry but did not yet show a bounded and ethically workable master's design.

## Validation

- `git diff --check`
- `npm test`
  - content architecture: passed (182 unique routes)
  - site integrity and internal links: passed
  - CSS, JavaScript, and formatting checks: passed

A local Jekyll build was not available because this environment does not include Ruby or Docker; GitHub CI remains the build check.