### PR TITLE
Refine professional title and research positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Revise the current canonical page in place as evidence, experience, or editorial
 
 Program records explain what a program is, where it came from, how it has been run, what has been observed, and what has not been demonstrated. Dates, prices, capacity, and registration calls belong on a current operational page and must not be mixed with research claims.
 
+### Keep the professional title evidence-aligned
+
+Use **Founder, Software Engineer, and Leadership Facilitator** as Mohammad's primary professional title. Describe research-related activity as practice-based inquiry rather than repeating *Independent Researcher* as a formal identity. Reserve *practitioner-researcher* for the Research Profile's explicit discussion of method and position, not homepage, biography, resume, project-role, or section-index titles.
+
 ### Publish articles with complete metadata and in-page navigation
 
 Every published article-like page must satisfy the metadata, language, SEO, and table-of-contents rules in this guide. Missing required front matter or a missing in-page table of contents blocks publication.
@@ -340,7 +344,7 @@ Reports with an explicit question, hypothesis, method, participants or dataset, 
 ### Research publishing model
 
 - `/research` — research portfolio overview;
-- `/research/profile` — practitioner-researcher identity and position;
+- `/research/profile` — practice-based inquiry, research interests, and position;
 - `/research/publications` — selected published and documented research-related work;
 - `/research/methods-ethics-evidence` — public evidence and participant-protection standard;
 - `/research/notes/...` — canonical research, field, literature, and design notes and reviews;

--- a/docs/about/biography/biography.md
+++ b/docs/about/biography/biography.md
@@ -4,7 +4,7 @@ title: Biography
 parent: About
 nav_order: 1
 direction: ltr
-description: "A short biography of Mohammad Bayat: founder, software engineer, leadership facilitator, and independent researcher."
+description: "A short biography of Mohammad Bayat: founder, software engineer, and leadership facilitator."
 permalink: /about/biography
 ---
 
@@ -12,13 +12,13 @@ permalink: /about/biography
 
 {% include components/profile_photo.html variant="biography" %}
 
-Mohammad Bayat is a founder and software engineer whose work spans quantitative systems, web applications, technical architecture, artificial intelligence, company-building, and leadership practice.
+Mohammad Bayat is a founder, software engineer, and leadership facilitator whose work spans quantitative systems, web applications, technical architecture, artificial intelligence, company-building, and leadership practice. His practice-based inquiry focuses on human learning, reflective practice, leadership, and durable change.
 
 He has worked in software development since the early 2010s, including front-end and back-end systems, real-time market applications, testing infrastructure, data visualization, and quantitative trading software. His main company-building work is organized around [K2Quant](/projects/k2quant).
 
 Over approximately a decade, he also led [FamilyLink](/projects/familylink), a family-support initiative that provided practical assistance and explored caregiver training and livelihood support. The project paused in 2026 after its funding and operating model proved insufficiently independent and durable. Its privacy-conscious public record separates reported activity from verified outcomes and documents what would be required for a responsible return.
 
-Alongside engineering, he maintains an independent program of inquiry into [Human Transformation](/leadership-learning/human-transformation). Its questions concern human learning, language, identity, worldview, context, performance, leadership, group coordination, and the conditions under which change becomes durable rather than dependent on a single environment.
+Alongside engineering and facilitation, he develops this inquiry through [Human Transformation](/leadership-learning/human-transformation). Its questions concern language, identity, worldview, context, performance, group coordination, and the conditions under which change becomes durable rather than dependent on a single environment.
 
 This work is informed by reading and by practice-based observation through leadership facilitation, coaching, organizational work, [Learning Circle](/leadership-learning/human-transformation/field-projects/learning-circle), [Mastery for Life](/leadership-learning/human-transformation/practice-programs/mastery-for-life), and [Vocora](/projects/vocora).
 

--- a/docs/about/resume.md
+++ b/docs/about/resume.md
@@ -12,9 +12,9 @@ permalink: /about/resume
 # Mohammad Bayat
 {: .no_toc }
 
-Founder, software engineer, leadership facilitator, and independent researcher with more than 15 years of experience building web, market, and quantitative software systems.
+Founder, Software Engineer, and Leadership Facilitator with more than 15 years of experience building web, market, and quantitative software systems.
 
-My current work is centered on [K2Quant](/projects/k2quant) and an independent inquiry into [Human Transformation](/leadership-learning/human-transformation), including [Learning Circle](/leadership-learning/human-transformation/field-projects/learning-circle), facilitated programs, leadership and organizational practice, and [Vocora](/projects/vocora). My longer project history also includes [FamilyLink](/projects/familylink), a family-support initiative that is currently paused.
+My practice-based inquiry focuses on human learning, reflective practice, leadership, and durable change. My current work is centered on [K2Quant](/projects/k2quant) and [Human Transformation](/leadership-learning/human-transformation), including [Learning Circle](/leadership-learning/human-transformation/field-projects/learning-circle), facilitated programs, leadership and organizational practice, and [Vocora](/projects/vocora). My longer project history also includes [FamilyLink](/projects/familylink), a family-support initiative that is currently paused.
 
 <details open markdown="block">
   <summary>Table of contents</summary>
@@ -25,14 +25,14 @@ My current work is centered on [K2Quant](/projects/k2quant) and an independent i
 
 ---
 
-## Selected Independent Research and Projects
+## Selected Practice-Based Inquiry and Projects
 {: .no_toc }
 
 ### Human Transformation
 
-#### Independent Researcher and Practitioner
+#### Practice-Based Inquiry
 
-An independent, practice-based inquiry into human learning, language, identity, context, performance, leadership, group coordination, and durable change.
+An inquiry grounded in practice and concerned with human learning, language, identity, context, performance, leadership, group coordination, and durable change.
 
 Selected work includes:
 
@@ -97,9 +97,9 @@ FamilyLink was a family-support and social-impact initiative intended to reduce 
 
 ### Vocora
 
-#### Independent Researcher and Builder
+#### Founder and Builder
 
-Vocora is an independent research-and-building project about learning, memory, language practice, motivation, and learning technology.
+Vocora is a research-and-building project about learning, memory, language practice, motivation, and learning technology.
 
 Current work includes:
 
@@ -110,7 +110,7 @@ Current work includes:
 - reviewing relevant work in retrieval practice, spaced practice, motivation, and language learning;
 - publishing assumptions, limitations, and research and design notes.
 
-Vocora is not presented as an academic affiliation, clinical project, or validated neuroscience intervention. Its current output is software and independent research documentation.
+Vocora is not presented as an academic affiliation, clinical project, or validated neuroscience intervention. Its current output is software and practice-based research documentation.
 
 [Project overview](/projects/vocora) · [Source code](https://github.com/OkBayat/vocora)
 

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -9,15 +9,15 @@ permalink: /research
 
 # Research
 
-{ A practitioner-researcher portfolio of selected work, evidence, and methods | fs-6 }
+{ Selected research-related work, evidence, and methods | fs-6 }
 
 My research interests developed through building software and organizations, facilitating leadership and learning, coaching, and examining how changes in performance survive—or fail to survive—outside the setting that first supported them.
 
-This is an independent research portfolio. It does not present professional experience as academic proof. It brings together selected published work while making sources, evidence types, ethical boundaries, and uncertainty visible.
+This portfolio does not present professional experience as academic proof. It brings together selected published work while making sources, evidence types, ethical boundaries, and uncertainty visible.
 
 ## Start Here
 
-- [Research Profile](/research/profile) explains the experience and enduring interests that shape my work as a practitioner-researcher.
+- [Research Profile](/research/profile) explains the experience, position, and enduring interests that shape my practice-based inquiry.
 - [Selected Research-Related Work](/research/publications) presents published and documented work with clear evidence boundaries.
 - [Methods, Ethics & Evidence](/research/methods-ethics-evidence) states how I distinguish observation, self-report, interpretation, and research evidence.
 - [Research Notes & Reviews](/research/notes) contains investigations, field notes, evidence reviews, and design questions.

--- a/docs/research/research-profile.md
+++ b/docs/research/research-profile.md
@@ -4,13 +4,13 @@ title: Research Profile
 parent: Research
 nav_order: 1
 direction: ltr
-description: "Mohammad Bayat's practitioner-researcher profile across learning, leadership, language, identity, coordination, and durable change."
+description: "Mohammad Bayat's practice-based research profile across learning, leadership, language, identity, coordination, and durable change."
 permalink: /research/profile
 ---
 
 # Research Profile
 
-I am an independent practitioner-researcher whose questions emerge from more than fifteen years of building software and organizations and from years of leadership facilitation, coaching, group learning, and reflective practice.
+In this profile, I use *practitioner-researcher* to describe my position in relation to the inquiry, not a professional title or an academic credential. My questions emerge from more than fifteen years of building software and organizations and from years of leadership facilitation, coaching, group learning, and reflective practice.
 
 My central interest is not change inside an exceptional moment. It is [what remains when the learning space disappears](/writing/essays/what-remains-when-learning-space-disappears-en): when the course ends, the facilitator leaves, the team changes, or the original context is gone.
 

--- a/index.md
+++ b/index.md
@@ -2,16 +2,16 @@
 title: Home
 layout: home
 nav_order: 1
-description: "Mohammad Bayat builds quantitative systems and organizations while studying human learning, language, identity, context, and durable transformation."
+description: "Mohammad Bayat is a founder, software engineer, and leadership facilitator whose practice-based inquiry focuses on human learning, reflective practice, leadership, and durable change."
 permalink: /
 ---
 
 # Mohammad Bayat
-{ Founder, Software Engineer, Leadership Facilitator, and Independent Researcher | fs-6 }
+{ Founder, Software Engineer, and Leadership Facilitator | fs-6 }
 
 {% include components/profile_photo.html variant="home" link="/about/biography" %}
 
-I build quantitative systems and organizations, and I study how language, identity, context, and learning shape human performance and durable change.
+I build quantitative systems and organizations. My practice-based inquiry focuses on human learning, reflective practice, leadership, and durable change.
 
 OkBayat.com is a research and practice portfolio: a selected record of the systems, organizations, projects, and writing I have built or published, together with the evidence and limits behind them.
 
@@ -40,7 +40,7 @@ OkBayat.com is a research and practice portfolio: a selected record of the syste
   type="Project"
   title="Vocora"
   question="How should a learning product distinguish activity, current performance, and durable learning?"
-  role="Founder, builder, and independent researcher"
+  role="Founder and builder"
   evidence="Open-source software, product metrics, and published research and design notes"
   limits="Current product use does not yet demonstrate long-term learning effectiveness"
   url="/projects/vocora"

--- a/scripts/validate_content_architecture.js
+++ b/scripts/validate_content_architecture.js
@@ -93,15 +93,40 @@ const pages = pageFiles.map(parsePage).filter(Boolean)
 const pagesByFile = new Map(pages.map((page) => [page.file, page]))
 const titles = new Set(pages.map((page) => page.data.title).filter(Boolean))
 const permalinks = new Map()
+const PRACTITIONER_RESEARCHER_PAGE = "docs/research/research-profile.md"
+const PROFESSIONAL_IDENTITY_PAGES = new Set([
+  "index.md",
+  "docs/about/biography/biography.md",
+  "docs/about/resume.md",
+  "docs/research/index.md",
+  PRACTITIONER_RESEARCHER_PAGE,
+])
 
 for (const page of pages) {
   const { data, file, body } = page
+  const publicCopy = `${JSON.stringify(data)}\n${body}`
 
   if (data.grand_parent !== undefined) {
     errors.add(`${file}: grand_parent is forbidden`)
   }
   if (data.has_children !== undefined) {
     errors.add(`${file}: has_children is forbidden`)
+  }
+  if (
+    PROFESSIONAL_IDENTITY_PAGES.has(file) &&
+    /\bindependent[ -]researcher\b/i.test(publicCopy)
+  ) {
+    errors.add(
+      `${file}: Independent Researcher must not be used as a public identity`
+    )
+  }
+  if (
+    /\bpractitioner[ -]researcher\b/i.test(publicCopy) &&
+    file !== PRACTITIONER_RESEARCHER_PAGE
+  ) {
+    errors.add(
+      `${file}: practitioner-researcher is reserved for the Research Profile`
+    )
   }
   if (data.parent && !titles.has(data.parent)) {
     errors.add(


### PR DESCRIPTION
## Summary

- use **Founder, Software Engineer, and Leadership Facilitator** as the primary professional title on the homepage and resume
- describe the research-related work as practice-based inquiry on the homepage, Biography, and Resume
- remove **Independent Researcher** from public identity, project-role, and resume headings
- reserve **practitioner-researcher** for the Research Profile's explicit discussion of method and position
- align the Research index and editorial guide with the revised positioning
- add an architecture check that prevents the removed identity from returning on core profile pages and keeps practitioner-researcher scoped to Research Profile

## Why

Repeating Independent Researcher across prominent surfaces could imply a formal academic identity that the site's current evidence and publication record do not support. The revised wording keeps inquiry visible while grounding the primary identity in established professional practice.

## User-facing impact

Visitors see one consistent professional title. Research interests remain discoverable and are described as practice-based inquiry, with practitioner-researcher used only where its methodological meaning and limits are explained.

## Validation

- `git diff --check`
- `npm run lint`
  - content architecture: passed
  - site integrity and internal links: passed
  - CSS, JavaScript, and formatting: passed
- remote diff verified against `main`: 1 commit, 7 files