### PR TITLE
Add selected work in human learning and transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A canonical page may be linked from one or more topical lenses:
 
 - All Writing
 - Selected Research-Related Work
+- Selected Work in Human Learning and Transformation
 - essay topic indexes
 - project indexes
 - Vocora Publications & Notes
@@ -213,7 +214,7 @@ Each hub provides the next layer of discovery:
 
 - **About** links Biography, Professional Journey, Mastery, Values, Curriculum Vitae, and Resume.
 - **Work** links the Projects and Leadership & Learning hubs, which in turn expose companies, software, leadership practice, facilitation, programs, courses, and project records.
-- **Research & Practice** links Research Profile, Selected Research-Related Work, Methods, Ethics & Evidence, Research Notes, and Timeline.
+- **Research & Practice** links Research Profile, Selected Research-Related Work, Selected Work in Human Learning and Transformation, Methods, Ethics & Evidence, Research Notes, and Timeline.
 - **Writing** links Essays, Reading Notes, Translations, Podcast, and All Writing.
 - **Contact** links Schedule a Meeting.
 
@@ -329,6 +330,7 @@ Reports with an explicit question, hypothesis, method, participants or dataset, 
 - `/research-practice` — research portfolio overview;
 - `/research-practice/profile` — practice-based inquiry, research interests, and position;
 - `/research-practice/publications` — selected published and documented research-related work;
+- `/research-practice/human-learning-transformation` — a focused path through work on reflective practice, changing learning contexts, group processes, facilitation, arts-informed inquiry, and leadership;
 - `/research-practice/methods-ethics-evidence` — public evidence and participant-protection standard;
 - `/research-practice/notes/...` — canonical research, field, literature, and design notes and reviews;
 - `/research-practice/timeline` — chronological archive of registered published work.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -20,6 +20,7 @@ This portfolio does not present professional experience as academic proof. It br
 
 - [Research Profile](/research-practice/profile) explains the experience, position, and enduring interests that shape my practice-based inquiry.
 - [Selected Research-Related Work](/research-practice/publications) presents published and documented work with clear evidence boundaries.
+- [Selected Work in Human Learning and Transformation](/research-practice/human-learning-transformation) provides a focused path through work on reflective practice, learning across changing contexts, group processes, facilitation, and leadership.
 - [Methods, Ethics & Evidence](/research-practice/methods-ethics-evidence) states how I distinguish observation, self-report, interpretation, and research evidence.
 - [Research Notes & Reviews](/research-practice/notes) contains investigations, field notes, evidence reviews, and design questions.
 - [Timeline](/research-practice/timeline) is a chronological archive of published essays, notes, reviews, and translations.

--- a/docs/research/methods-ethics-evidence.md
+++ b/docs/research/methods-ethics-evidence.md
@@ -2,7 +2,7 @@
 layout: default
 title: Methods, Ethics & Evidence
 parent: Research & Practice
-nav_order: 3
+nav_order: 4
 direction: ltr
 description: "Standards for evidence, consent, privacy, role conflicts, and research-facing public work on okbayat.com."
 last_modified_date: 2026-07-24

--- a/docs/research/notes/index.md
+++ b/docs/research/notes/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Research Notes
 parent: Research & Practice
-nav_order: 4
+nav_order: 5
 nav_exclude: false
 direction: ltr
 description: "Working investigations, evidence reviews, field observations, and design decisions grouped by their primary body of work."

--- a/docs/research/publications-en.md
+++ b/docs/research/publications-en.md
@@ -16,6 +16,8 @@ This page is a curated index of published and documented work related to human l
 
 A work may appear under more than one theme because learning, identity, relationships, leadership, language, and worldview overlap. Cross-listing does not create a second copy of the page.
 
+For a shorter route through the work on reflective practice, changing learning contexts, group processes, facilitation, arts-informed inquiry, and leadership, see [Selected Work in Human Learning and Transformation](/research-practice/human-learning-transformation).
+
 ## Program and Field Records
 
 - [Learning Circle](/work/leadership-learning/human-transformation/field-projects/learning-circle) — children's autonomy, peer teaching, group coordination, and facilitator withdrawal.

--- a/docs/research/research-profile.md
+++ b/docs/research/research-profile.md
@@ -40,3 +40,5 @@ My practice-based inquiry focuses on:
 - the relationship between context, identity, and the availability of prior learning.
 
 My approach to evidence and participant protection is stated in [Methods, Ethics & Evidence](/research-practice/methods-ethics-evidence).
+
+A focused route through the essays, notes, and field records most closely connected to these questions is available in [Selected Work in Human Learning and Transformation](/research-practice/human-learning-transformation).

--- a/docs/research/selected-human-learning-transformation.md
+++ b/docs/research/selected-human-learning-transformation.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: Selected Work in Human Learning and Transformation
+parent: Research & Practice
+nav_order: 3
+direction: ltr
+lang: en
+locale: en_US
+description: "A focused path through Mohammad Bayat's work on reflective practice, changing learning contexts, group processes, facilitator withdrawal, arts-informed inquiry, and leadership."
+last_modified_date: 2026-07-24
+permalink: /research-practice/human-learning-transformation
+---
+
+# Selected Work in Human Learning and Transformation
+
+These six works provide a focused path through my inquiry into how learning and reflection are shaped by groups, facilitators, organizations, and changing contexts. Together, they ask not only what becomes possible inside a supportive learning space, but what a person or group can continue, recreate, or revise when that space changes.
+
+This is a discovery page, not a separate publication category. Each work remains in its canonical section with its original content type, evidence boundary, and revision history.
+
+## Learning Across Changing Contexts
+
+### [What Remains When the Learning Space Disappears?](/writing/essays/what-remains-when-learning-space-disappears-en)
+
+**Essay · Evidence-aware synthesis**
+
+Distinguishes performance inside a supportive setting from learning, transfer, and durable capacity. It asks what remains when the course ends, the facilitator leaves, the team changes, or the learner enters a context that does not reinforce the same practices.
+
+### [Can the Learner Carry the Context?](/research-practice/notes/can-the-learner-carry-the-context)
+
+**Research Note · Published study and practice-based interpretation**
+
+Examines reflective practice, double-loop learning, and uneven transfer from educational settings into work. The central question is whether learning changes only a response or also changes how the learner notices, questions, and participates in a new context.
+
+### [Learning Circle](/work/leadership-learning/human-transformation/field-projects/learning-circle)
+
+**Field Project Record · Historical practice record**
+
+Documents a learning community organized around peer teaching, learner ownership, group coordination, and gradual facilitator withdrawal. It also makes clear what the incomplete historical record, role conflicts, and safeguarding limits do not allow the project to claim.
+
+## Groups, Arts-Informed Inquiry, and Human Systems
+
+### [When Conversation Is Not Enough: How Art Can Make Group Dynamics Discussable](/research-practice/notes/art-groupwork-communication-en)
+
+**Reading Note · Arts-based action research**
+
+Explores how artistic forms can make hidden conflict, power, fear, and dependence available for collective inquiry. It treats recurring difficulty as a pattern sustained within a group system rather than as a defect located in one person.
+
+### [What Are Learners Actually Committed To?](/research-practice/notes/commitment-context-learning-en)
+
+**Research Note · Field-based inquiry**
+
+Asks how the actual object of a learner's commitment may organize attention, questions, help seeking, persistence, and coordination in project-based leadership education. It distinguishes commitment to a meaningful result from commitment to trying, planning, compliance, or appearing active.
+
+### [When the Question Changes, the Organization Changes](/writing/essays/when-the-question-changes-en)
+
+**Leadership Essay · Practice-based organizational inquiry**
+
+Examines how an organizing question can shape what people notice, value, learn, and coordinate around. It connects leadership with the possibility of changing how a human system understands its work, rather than only correcting behavior inside the existing frame.
+
+## How to Read This Selection
+
+The six works do not have the same evidence status. They include original essays, research notes, a reading of published action research, and a retrospective field-project record. Inclusion here means that a work is closely related to the inquiry and explicit about what supports its claims; it does not mean that the work has been peer reviewed or that the questions have been resolved.
+
+The standards used to distinguish published evidence, observation, participant self-report, interpretation, and open questions are described in [Methods, Ethics & Evidence](/research-practice/methods-ethics-evidence). The broader portfolio remains available through [Selected Research-Related Work](/research-practice/publications).

--- a/docs/research/timeline.md
+++ b/docs/research/timeline.md
@@ -2,7 +2,7 @@
 layout: default
 title: Timeline
 parent: Research & Practice
-nav_order: 5
+nav_order: 6
 direction: ltr
 lang: en
 locale: en_US

--- a/scripts/validate_content_architecture.js
+++ b/scripts/validate_content_architecture.js
@@ -182,20 +182,25 @@ const expectedPages = {
     "Research & Practice",
     "2",
   ],
+  "docs/research/selected-human-learning-transformation.md": [
+    "/research-practice/human-learning-transformation",
+    "Research & Practice",
+    "3",
+  ],
   "docs/research/methods-ethics-evidence.md": [
     "/research-practice/methods-ethics-evidence",
     "Research & Practice",
-    "3",
+    "4",
   ],
   "docs/research/notes/index.md": [
     "/research-practice/notes",
     "Research & Practice",
-    "4",
+    "5",
   ],
   "docs/research/timeline.md": [
     "/research-practice/timeline",
     "Research & Practice",
-    "5",
+    "6",
   ],
   "docs/writing/essays/index.md": ["/writing/essays", "Writing", "1"],
   "docs/writing/reading-notes/index.md": [
@@ -382,6 +387,39 @@ if (cv) {
     if (pdf.length < 10_000 || pdf.subarray(0, 5).toString() !== "%PDF-") {
       errors.add("docs/about/cv.md: downloadable CV PDF is invalid")
     }
+  }
+}
+
+const humanLearningSelection = pagesByFile.get(
+  "docs/research/selected-human-learning-transformation.md"
+)
+if (humanLearningSelection) {
+  const requiredRoutes = [
+    "/writing/essays/what-remains-when-learning-space-disappears-en",
+    "/research-practice/notes/can-the-learner-carry-the-context",
+    "/work/leadership-learning/human-transformation/field-projects/learning-circle",
+    "/research-practice/notes/art-groupwork-communication-en",
+    "/research-practice/notes/commitment-context-learning-en",
+    "/writing/essays/when-the-question-changes-en",
+  ]
+  const selectedRoutes = extractInternalRoutes(humanLearningSelection.body)
+
+  for (const route of requiredRoutes) {
+    if (!selectedRoutes.includes(route)) {
+      errors.add(
+        `docs/research/selected-human-learning-transformation.md: missing selected work ${route}`
+      )
+    }
+  }
+
+  if (
+    /Rosemary Reilly|admission|application|HSI reviewer|prospective supervisor/i.test(
+      humanLearningSelection.body
+    )
+  ) {
+    errors.add(
+      "docs/research/selected-human-learning-transformation.md: selected path must remain audience-neutral"
+    )
   }
 }
 


### PR DESCRIPTION
## What changed

- Added a focused `Selected Work in Human Learning and Transformation` page with six canonical works.
- Organized the selection around learning across changing contexts, reflective practice, learning communities, facilitator withdrawal, group processes, arts-informed inquiry, commitment, leadership, and human systems.
- Linked the page naturally from Research & Practice, Research Profile, and Selected Research-Related Work.
- Kept each selected work in its canonical section with its existing content type and evidence boundary.
- Reordered Research & Practice children so the focused path appears before methods, notes, and the timeline.
- Updated the editorial guide and added architecture guards for the route, position, six selected works, and audience-neutral framing.

## Why

Readers interested in human learning and transformation currently have to assemble this line of inquiry across essays, research notes, reading notes, and field records. The new page provides a short, coherent route without duplicating content or presenting the site as designed for a particular professor, application, or reviewer.

## Validation

- `npm test`
- Content architecture: 182 source pages and 182 unique routes
- Site integrity: 183 source pages with consistent language metadata and internal links
- Prettier, SCSS, and JavaScript validation
- `git diff --check`
- GitHub comparison confirms one commit and nine changed files
- Local and remote Git tree SHA: `9ab3dd78f068441fca6c6d579e8886c168c86f79`
