### PR TITLE
Generate CV PDF during Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,19 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Install CV generator dependencies
+        run: |
+          if [ ! -f /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf ]; then
+            sudo apt-get update
+            sudo apt-get install --yes fonts-dejavu-core
+          fi
+          python -m pip install --disable-pip-version-check "reportlab==5.0.0"
+      - name: Generate CV PDF
+        run: python scripts/generate_cv_pdf.py
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3


### PR DESCRIPTION
## What changed

- sets up Python 3.13 in the GitHub Pages build job
- installs the pinned ReportLab dependency and ensures DejaVu Sans is available
- runs `python scripts/generate_cv_pdf.py` before the Jekyll build

## Why

`docs/about/cv.md` is the source of truth for the CV, but the downloadable PDF previously had to be regenerated manually. Running the existing generator during deployment keeps the deployed PDF synchronized with the Markdown source.

## Impact

After this PR is merged, every deployment from `main` will regenerate `assets/downloads/mohammad-bayat-cv.pdf` in the Actions workspace before Jekyll builds the site. The generated PDF is included in the deployed Pages artifact; the workflow does not create automated commits.

## Validation

- verified the edited workflow parses as valid YAML
- verified the generator runs before the Jekyll build and artifact upload
- pinned `reportlab==5.0.0` for reproducible dependency resolution
